### PR TITLE
[Refactor] 팀/아티스트 구독 관련 로직 추가 및 수정

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
@@ -8,6 +8,7 @@ import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.service.ArtistService;
+import com.happiday.Happi_Day.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ public class ArtistController {
 
     private final ArtistService artistService;
 
+    // 아티스트 등록
     @PostMapping
     public ResponseEntity<ArtistDetailResponseDto> registerArtist(@RequestPart(name = "artist") ArtistRegisterDto requestDto,
                                                                   @RequestPart(value = "file", required = false) MultipartFile imageFile) {
@@ -30,6 +32,7 @@ public class ArtistController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    // 아티스트 정보 수정
     @PutMapping("/{artistId}")
     public ResponseEntity<ArtistDetailResponseDto> updateArtist(@PathVariable Long artistId,
                                                                 @RequestPart(name = "artist") ArtistUpdateDto requestDto,
@@ -38,39 +41,62 @@ public class ArtistController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    // 아티스트 삭제
     @DeleteMapping("/{artistId}")
     public ResponseEntity<Void> deleteArtist(@PathVariable Long artistId) {
         artistService.delete(artistId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    // 아티스트 상세 조회
     @GetMapping("/{artistId}")
     public ResponseEntity<ArtistDetailResponseDto> getArtist(@PathVariable Long artistId) {
-        ArtistDetailResponseDto responseDto = artistService.getArtist(artistId);
+        String username = SecurityUtils.getCurrentUsername();
+        ArtistDetailResponseDto responseDto = artistService.getArtist(artistId, username);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    // 아티스트 목록 조회
     @GetMapping
     public ResponseEntity<List<ArtistListResponseDto>> getArtists() {
         List<ArtistListResponseDto> responseDtos = artistService.getArtists();
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 
+    // 아티스트가 속한 팀 목록 조회
     @GetMapping("/{artistId}/teams")
     public ResponseEntity<List<TeamListResponseDto>> getArtistTeams(@PathVariable Long artistId) {
         List<TeamListResponseDto> artistTeams = artistService.getArtistTeams(artistId);
         return new ResponseEntity<>(artistTeams, HttpStatus.OK);
     }
 
+    // 아티스트 관련 상품 목록 조회
     @GetMapping("/{artistId}/sales")
     public ResponseEntity<List<SalesListResponseDto>> getArtistSales(@PathVariable Long artistId) {
         List<SalesListResponseDto> responseDtos = artistService.getSalesList(artistId);
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 
+    // 아티스트의 이벤트 목록 조회
     @GetMapping("/{artistId}/events")
     public ResponseEntity<List<EventListResponseDto>> getArtistEvents(@PathVariable Long artistId) {
         List<EventListResponseDto> responseDtos = artistService.getEvents(artistId);
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+    }
+
+    // 아티스트 구독
+    @PostMapping("/{artistId}/subscribe")
+    public ResponseEntity<Void> subscribeToArtist(@PathVariable Long artistId) {
+        String username = SecurityUtils.getCurrentUsername();
+        artistService.subscribeToArtist(username, artistId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 아티스트 구독 취소
+    @PostMapping("/{artistId}/unsubscribe")
+    public ResponseEntity<Void> unsubscribeFromArtist(@PathVariable Long artistId) {
+        String username = SecurityUtils.getCurrentUsername();
+        artistService.unsubscribeFromArtist(username, artistId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/SubscriptionController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/SubscriptionController.java
@@ -1,0 +1,69 @@
+package com.happiday.Happi_Day.domain.controller;
+
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.CombinedSubscriptionsDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.SubscriptionRequestDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.SubscriptionsResponseDto;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
+import com.happiday.Happi_Day.domain.service.SubscriptionService;
+import com.happiday.Happi_Day.utils.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/subscriptions")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    // 구독 페이지 조회 (구독 중 팀/아티스트 + 구독 중이지 않은 팀/아티스트 목록 조회)
+    @GetMapping("/overview")
+    public ResponseEntity<CombinedSubscriptionsDto> getSubscriptionOverview(Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        CombinedSubscriptionsDto combinedSubscriptions = subscriptionService.getSubscriptionsWithUnsubscribed(username, pageable);
+        return ResponseEntity.ok(combinedSubscriptions);
+    }
+
+    // 현재 구독 중인 팀/아티스트 목록 조회
+    @GetMapping
+    public ResponseEntity<SubscriptionsResponseDto> getCurrentSubscriptions() {
+        String username = SecurityUtils.getCurrentUsername();
+        return ResponseEntity.ok(subscriptionService.getCurrentSubscriptions(username));
+    }
+
+    // 구독 추가
+    @PostMapping
+    public ResponseEntity<Void> addSubscription(@RequestBody SubscriptionRequestDto requestDto) {
+        String username = SecurityUtils.getCurrentUsername();
+        subscriptionService.addSubscription(username, requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 구독 취소
+    @DeleteMapping
+    public ResponseEntity<Void> cancelSubscription(
+            @RequestParam(required = false) Long artistId,
+            @RequestParam(required = false) Long teamId) {
+        String username = SecurityUtils.getCurrentUsername();
+        subscriptionService.cancelSubscription(username, artistId, teamId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 구독하지 않은 아티스트 조회
+    @GetMapping("/undiscovered/artists")
+    public ResponseEntity<Page<ArtistListResponseDto>> getUnsubscribedArtists(Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return ResponseEntity.ok(subscriptionService.getSubscribedArtists(username, pageable));
+    }
+
+    // 구독하지 않은 팀 조회
+    @GetMapping("/undiscovered/teams")
+    public ResponseEntity<Page<TeamListResponseDto>> getUnsubscribedTeams(Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return ResponseEntity.ok(subscriptionService.getUnSubscribedTeams(username, pageable));
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
@@ -8,6 +8,7 @@ import com.happiday.Happi_Day.domain.entity.team.dto.TeamRegisterDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamDetailResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamUpdateDto;
 import com.happiday.Happi_Day.domain.service.TeamService;
+import com.happiday.Happi_Day.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ public class TeamController {
 
     private final TeamService teamService;
 
+    // 팀 등록
     @PostMapping
     public ResponseEntity<TeamDetailResponseDto> registerTeam(@RequestPart(name = "team") TeamRegisterDto requestDto,
                                                               @RequestPart(value = "file", required = false) MultipartFile imageFile) {
@@ -30,6 +32,7 @@ public class TeamController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    // 팀 정보 수정
     @PutMapping("/{teamId}")
     public ResponseEntity<TeamDetailResponseDto> updateTeam(@PathVariable Long teamId,
                                                             @RequestPart(name = "team") TeamUpdateDto requestDto,
@@ -38,39 +41,62 @@ public class TeamController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    // 팀 삭제
     @DeleteMapping("/{teamId}")
     public ResponseEntity<Void> deleteTeam(@PathVariable Long teamId) {
         teamService.deleteTeam(teamId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    // 팀 상세 조회
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamDetailResponseDto> getTeam(@PathVariable Long teamId) {
-        TeamDetailResponseDto responseDto = teamService.getTeam(teamId);
+        String username = SecurityUtils.getCurrentUsername();
+        TeamDetailResponseDto responseDto = teamService.getTeam(teamId, username);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    // 팀 목록 조회
     @GetMapping
     public ResponseEntity<List<TeamListResponseDto>> getTeams() {
         List<TeamListResponseDto> responseDtos = teamService.getTeams();
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 
+    // 팀 소속 아티스트 목록 조회
     @GetMapping("/{teamId}/artists")
     public ResponseEntity<List<ArtistListResponseDto>> getArtistsByTeam(@PathVariable Long teamId) {
         List<ArtistListResponseDto> teamArtists = teamService.getTeamArtists(teamId);
         return new ResponseEntity<>(teamArtists, HttpStatus.OK);
     }
 
+    // 팀 관련 상품 목록 조회
     @GetMapping("/{teamId}/sales")
     public ResponseEntity<List<SalesListResponseDto>> getTeamSales(@PathVariable Long teamId) {
         List<SalesListResponseDto> responseDtos = teamService.getSalesList(teamId);
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
     }
 
+    // 팀의 이벤트 목록 조회
     @GetMapping("/{teamId}/events")
     public ResponseEntity<List<EventListResponseDto>> getArtistEvents(@PathVariable Long teamId) {
         List<EventListResponseDto> responseDtos = teamService.getEvents(teamId);
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
+    }
+
+    // 팀 구독
+    @PostMapping("/{teamId}/subscribe")
+    public ResponseEntity<Void> subscribeToTeam(@PathVariable Long teamId) {
+        String username = SecurityUtils.getCurrentUsername();
+        teamService.subscribeToTeam(username, teamId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 팀 구독 취소
+    @PostMapping("/{teamId}/unsubscribe")
+    public ResponseEntity<Void> unsubscribeFromTeam(@PathVariable Long teamId) {
+        String username = SecurityUtils.getCurrentUsername();
+        teamService.unsubscribeFromTeam(username, teamId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistDetailResponseDto.java
@@ -2,8 +2,11 @@ package com.happiday.Happi_Day.domain.entity.artist.dto;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistType;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -14,8 +17,10 @@ public class ArtistDetailResponseDto {
     private String description;
     private String profileUrl;
     private String nationality;
+    private boolean isSubscribed;
+    private List<TeamListResponseDto> teams;
 
-    public static ArtistDetailResponseDto of(Artist artist) {
+    public static ArtistDetailResponseDto of(Artist artist, boolean isSubscribed) {
         return ArtistDetailResponseDto.builder()
                 .id(artist.getId())
                 .name(artist.getName())
@@ -23,6 +28,20 @@ public class ArtistDetailResponseDto {
                 .description(artist.getDescription())
                 .profileUrl(artist.getProfileUrl())
                 .nationality(artist.getNationality())
+                .isSubscribed(isSubscribed)
+                .build();
+    }
+
+    public static ArtistDetailResponseDto of(Artist artist, boolean isSubscribed, List<TeamListResponseDto> teams) {
+        return ArtistDetailResponseDto.builder()
+                .id(artist.getId())
+                .name(artist.getName())
+                .type(artist.getType())
+                .description(artist.getDescription())
+                .profileUrl(artist.getProfileUrl())
+                .nationality(artist.getNationality())
+                .isSubscribed(isSubscribed)
+                .teams(teams)
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/CombinedSubscriptionsDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/CombinedSubscriptionsDto.java
@@ -13,16 +13,16 @@ public class CombinedSubscriptionsDto {
     private List<ArtistListResponseDto> subscribedArtists;
     private List<TeamListResponseDto> subscribedTeams;
     private List<ArtistListResponseDto> unsubscribedArtists;
-    private List<TeamListResponseDto> unsubscribedTeas;
+    private List<TeamListResponseDto> unsubscribedTeams;
 
     public CombinedSubscriptionsDto(
             List<ArtistListResponseDto> subscribedArtists,
             List<TeamListResponseDto> subscribedTeams,
             List<ArtistListResponseDto> unsubscribedArtists,
-            List<TeamListResponseDto> unsubscribedTeas) {
+            List<TeamListResponseDto> unsubscribedTeams) {
         this.subscribedArtists = subscribedArtists;
         this.subscribedTeams = subscribedTeams;
         this.unsubscribedArtists = unsubscribedArtists;
-        this.unsubscribedTeas = unsubscribedTeas;
+        this.unsubscribedTeams = unsubscribedTeams;
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/CombinedSubscriptionsDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/CombinedSubscriptionsDto.java
@@ -1,0 +1,28 @@
+package com.happiday.Happi_Day.domain.entity.subscription.dto;
+
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CombinedSubscriptionsDto {
+    private List<ArtistListResponseDto> subscribedArtists;
+    private List<TeamListResponseDto> subscribedTeams;
+    private List<ArtistListResponseDto> unsubscribedArtists;
+    private List<TeamListResponseDto> unsubscribedTeas;
+
+    public CombinedSubscriptionsDto(
+            List<ArtistListResponseDto> subscribedArtists,
+            List<TeamListResponseDto> subscribedTeams,
+            List<ArtistListResponseDto> unsubscribedArtists,
+            List<TeamListResponseDto> unsubscribedTeas) {
+        this.subscribedArtists = subscribedArtists;
+        this.subscribedTeams = subscribedTeams;
+        this.unsubscribedArtists = unsubscribedArtists;
+        this.unsubscribedTeas = unsubscribedTeas;
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/SubscriptionRequestDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/SubscriptionRequestDto.java
@@ -1,0 +1,11 @@
+package com.happiday.Happi_Day.domain.entity.subscription.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubscriptionRequestDto {
+    private Long artistId;
+    private Long teamId;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/SubscriptionsResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/SubscriptionsResponseDto.java
@@ -1,0 +1,17 @@
+package com.happiday.Happi_Day.domain.entity.subscription.dto;
+
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SubscriptionsResponseDto {
+    private List<ArtistListResponseDto> subscribedArtists;
+    private List<TeamListResponseDto> subscribedTeams;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/UnsubscriptionResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/subscription/dto/UnsubscriptionResponseDto.java
@@ -1,0 +1,17 @@
+package com.happiday.Happi_Day.domain.entity.subscription.dto;
+
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UnsubscriptionResponseDto {
+    private List<ArtistListResponseDto> subscribedArtists;
+    private List<TeamListResponseDto> subscribedTeams;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/team/dto/TeamDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/team/dto/TeamDetailResponseDto.java
@@ -1,8 +1,11 @@
 package com.happiday.Happi_Day.domain.entity.team.dto;
 
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -11,13 +14,27 @@ public class TeamDetailResponseDto {
     private String name;
     private String description;
     private String logoUrl;
+    private boolean isSubscribed;
+    private List<ArtistListResponseDto> artists;
 
-    public static TeamDetailResponseDto of(Team team) {
+    public static TeamDetailResponseDto of(Team team, boolean isSubscribed) {
         return TeamDetailResponseDto.builder()
                 .id(team.getId())
                 .name(team.getName())
                 .description(team.getDescription())
                 .logoUrl(team.getLogoUrl())
+                .isSubscribed(isSubscribed)
+                .build();
+    }
+
+    public static TeamDetailResponseDto of(Team team, boolean isSubscribed, List<ArtistListResponseDto> artists) {
+        return TeamDetailResponseDto.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .logoUrl(team.getLogoUrl())
+                .isSubscribed(isSubscribed)
+                .artists(artists)
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistRepository.java
@@ -1,11 +1,17 @@
 package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
     Optional<Artist> findByName(String artistName);
 
+    @Query("SELECT a FROM Artist a WHERE a.id NOT IN (SELECT ua.id FROM User u JOIN u.subscribedArtists ua WHERE u.id = :userId)")
+    Page<Artist> findUnsubscribedArtists(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/TeamRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/TeamRepository.java
@@ -1,10 +1,17 @@
 package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.team.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String teamName);
+
+    @Query("SELECT t FROM Team t WHERE t.id NOT IN (SELECT ut.id FROM User u JOIN u.subscribedTeams ut WHERE u.id = :userId)")
+    Page<Team> findUnsubscribedTeams(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/SubscriptionService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/SubscriptionService.java
@@ -1,0 +1,137 @@
+package com.happiday.Happi_Day.domain.service;
+
+import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.CombinedSubscriptionsDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.SubscriptionRequestDto;
+import com.happiday.Happi_Day.domain.entity.subscription.dto.SubscriptionsResponseDto;
+import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
+import com.happiday.Happi_Day.domain.entity.user.User;
+import com.happiday.Happi_Day.domain.repository.ArtistRepository;
+import com.happiday.Happi_Day.domain.repository.TeamRepository;
+import com.happiday.Happi_Day.domain.repository.UserRepository;
+import com.happiday.Happi_Day.exception.CustomException;
+import com.happiday.Happi_Day.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionService {
+    private final UserRepository userRepository;
+    private final ArtistRepository artistRepository;
+    private final TeamRepository teamRepository;
+
+    // 구독 페이지 조회 (구독 중 팀/아티스트 + 구독 중이지 않은 팀/아티스트 목록 조회)
+    public CombinedSubscriptionsDto getSubscriptionsWithUnsubscribed(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 구독 중인 아티스트와 팀
+        List<ArtistListResponseDto> subscribedArtists = user.getSubscribedArtists().stream()
+                .map(ArtistListResponseDto::of)
+                .collect(Collectors.toList());
+        List<TeamListResponseDto> subscribedTeams = user.getSubscribedTeams().stream()
+                .map(TeamListResponseDto::of)
+                .collect(Collectors.toList());
+
+        // 구독하지 않은 아티스트와 팀
+        List<ArtistListResponseDto> unsubscribedArtists = artistRepository.findUnsubscribedArtists(user.getId(), pageable).stream()
+                .map(ArtistListResponseDto::of)
+                .collect(Collectors.toList());
+        List<TeamListResponseDto> unsubscribedTeams = teamRepository.findUnsubscribedTeams(user.getId(), pageable).stream()
+                .map(TeamListResponseDto::of)
+                .collect(Collectors.toList());
+
+        return new CombinedSubscriptionsDto(subscribedArtists, subscribedTeams, unsubscribedArtists, unsubscribedTeams);
+    }
+
+    // 현재 구독 중인 팀/아티스트 목록 조회
+    @Transactional(readOnly = true)
+    public SubscriptionsResponseDto getCurrentSubscriptions(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<ArtistListResponseDto> subscribedArtists = user.getSubscribedArtists().stream()
+                .map(ArtistListResponseDto::of)
+                .collect(Collectors.toList());
+
+        List<TeamListResponseDto> subscribedTeams = user.getSubscribedTeams().stream()
+                .map(TeamListResponseDto::of)
+                .collect(Collectors.toList());
+
+        return new SubscriptionsResponseDto(subscribedArtists, subscribedTeams);
+    }
+
+    // 구독 추가
+    @Transactional
+    public void addSubscription(String username, SubscriptionRequestDto requestDto) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (requestDto.getArtistId() != null) {
+            Artist artist = artistRepository.findById(requestDto.getArtistId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ARTIST_NOT_FOUND));
+            if (!user.getSubscribedArtists().contains(artist)) {
+                user.getSubscribedArtists().add(artist);
+            }
+        }
+
+        if (requestDto.getTeamId() != null) {
+            Team team = teamRepository.findById(requestDto.getTeamId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+            if (!user.getSubscribedTeams().contains(team)) {
+                user.getSubscribedTeams().add(team);
+            }
+        }
+
+        userRepository.save(user);
+    }
+
+    // 구독 취소
+    @Transactional
+    public void cancelSubscription(String username, Long artistId, Long teamId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (artistId != null) {
+            Artist artist = artistRepository.findById(artistId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.ARTIST_NOT_FOUND));
+            user.getSubscribedArtists().remove(artist);
+        }
+
+        if (teamId != null) {
+            Team team = teamRepository.findById(teamId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+            user.getSubscribedTeams().remove(team);
+        }
+
+        userRepository.save(user);
+    }
+
+    // 구독하지 않은 아티스트 조회
+    public Page<ArtistListResponseDto> getSubscribedArtists(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return artistRepository.findUnsubscribedArtists(user.getId(), pageable)
+                .map(ArtistListResponseDto::of);
+    }
+
+    // 구독하지 않은 팀 조회
+    public Page<TeamListResponseDto> getUnSubscribedTeams(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return teamRepository.findUnsubscribedTeams(user.getId(), pageable)
+                .map(TeamListResponseDto::of);
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
@@ -8,7 +8,9 @@ import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamRegisterDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamDetailResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamUpdateDto;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.TeamRepository;
+import com.happiday.Happi_Day.domain.repository.UserRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
 import com.happiday.Happi_Day.utils.FileUtils;
@@ -29,7 +31,9 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final FileUtils fileUtils;
+    private final UserRepository userRepository;
 
+    // 팀 등록
     @Transactional
     public TeamDetailResponseDto registerTeam(TeamRegisterDto requestDto, MultipartFile imageFile) {
         Team teamEntity = requestDto.toEntity();
@@ -41,9 +45,10 @@ public class TeamService {
         }
 
         teamEntity = teamRepository.save(teamEntity);
-        return TeamDetailResponseDto.of(teamEntity);
+        return TeamDetailResponseDto.of(teamEntity, false);
     }
 
+    // 팀 정보 수정
     @Transactional
     public TeamDetailResponseDto updateTeam(Long teamId, TeamUpdateDto requestDto, MultipartFile imageFile) {
         Team team = teamRepository.findById(teamId)
@@ -71,9 +76,10 @@ public class TeamService {
         team.update(requestDto.toEntity());
         teamRepository.save(team);
 
-        return TeamDetailResponseDto.of(team);
+        return TeamDetailResponseDto.of(team, false);
     }
 
+    // 팀 삭제
     @Transactional
     public void deleteTeam(Long teamId) {
         Team team = teamRepository.findById(teamId)
@@ -81,18 +87,28 @@ public class TeamService {
         teamRepository.delete(team);
     }
 
-    public TeamDetailResponseDto getTeam(Long teamId) {
+    // 팀 상세 조회
+    public TeamDetailResponseDto getTeam(Long teamId, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
-        return TeamDetailResponseDto.of(team);
+        boolean isSubscribed = user.getSubscribedTeams().contains(team);
+        // 팀에 소속된 아티스트 정보 가져오기
+        List<ArtistListResponseDto> artists = team.getArtists().stream()
+                .map(ArtistListResponseDto::of)
+                .collect(Collectors.toList());
+        return TeamDetailResponseDto.of(team, isSubscribed, artists);
     }
 
+    // 팀 목록 조회
     public List<TeamListResponseDto> getTeams() {
         return teamRepository.findAll().stream()
                 .map(TeamListResponseDto::of)
                 .collect(Collectors.toList());
     }
 
+    // 팀 소속 아티스트 목록 조회
     public List<ArtistListResponseDto> getTeamArtists(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
@@ -102,6 +118,7 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
+    // 팀 관련 상품 목록 조회
     public List<SalesListResponseDto> getSalesList(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
@@ -111,6 +128,7 @@ public class TeamService {
                 .collect(Collectors.toList());
     }
 
+    // 팀의 이벤트 목록 조회
     public List<EventListResponseDto> getEvents(Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
@@ -118,5 +136,29 @@ public class TeamService {
         return team.getEvents().stream()
                 .map(EventListResponseDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    // 팀 구독
+    @Transactional
+    public void subscribeToTeam(String username, Long teamId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+        if (!user.getSubscribedTeams().contains(team)) {
+            user.getSubscribedTeams().add(team);
+            userRepository.save(user);
+        }
+    }
+
+    // 팀 구독 취소
+    @Transactional
+    public void unsubscribeFromTeam(String username, Long teamId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+        user.getSubscribedTeams().remove(team);
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [x] 커밋 메시지, 브랜치명 컨벤션 확인
- [x] 병합되는 브랜치가 Develop인지 확인
- [x] 기능 수정 시에 테스트 코드 수정 확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 이슈 연동 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #133 
close #133 

## 🎯 변경 사항 요약
- 팀/아티스트 구독 관련 로직 추가 및 수정

## 📣 변경 사항 상세
- [x] 한 페이지에서 구독 중인 팀/아티스트와 구독 중이지 않은 팀/아티스트를 조회할 수 있는 엔드포인트와 로직 추가
- [x] 기존의 팀/아티스트 상세 조회 페이지에서 구독 및 취소를 할 수 있는 로직 추가
- [x]  bool값을 사용하여 프론트에서 구독 여부를 확인할 수 있도록 dto 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
- 아직 아티스트의 소속 팀과 팀의 소속 아티스트를 조회할 수 있는 로직이 빠져있음
- 현재 반환 dto만 추가했으며, 이후 로직 또한 추가할 예정