### PR TITLE
[Feature] 유저, 어드민 기능 추가

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
+++ b/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
@@ -47,8 +47,8 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(authHttp -> authHttp
                         .requestMatchers(
                                 HttpMethod.POST,
-                                "/api/v1/teams/**",
-                                "/api/v1/artists/**"
+                                "/api/v1/teams",
+                                "/api/v1/artists"
                         ).hasRole("ADMIN")
                         .requestMatchers(
                                 HttpMethod.PUT,

--- a/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
+++ b/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.happiday.Happi_Day.config;
 
+import com.happiday.Happi_Day.domain.entity.user.RoleType;
 import com.happiday.Happi_Day.jwt.JwtTokenFilter;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -15,6 +17,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -41,10 +46,26 @@ public class WebSecurityConfig {
                 )
                 .authorizeHttpRequests(authHttp -> authHttp
                         .requestMatchers(
+                                HttpMethod.POST,
+                                "/api/v1/teams/**",
+                                "/api/v1/artists/**"
+                        ).hasRole("ADMIN")
+                        .requestMatchers(
+                                HttpMethod.PUT,
+                                "/api/v1/teams/**",
+                                "/api/v1/artists/**"
+                        ).hasRole("ADMIN")
+                        .requestMatchers(
+                                HttpMethod.DELETE,
+                                "/api/v1/teams/**",
+                                "/api/v1/artists/**"
+                        ).hasRole("ADMIN")
+                        .requestMatchers(
                                 HttpMethod.GET,
                                 "/",
-                                "/api/v1/chat",
-                                "/api/v1/events/**"
+                                "/api/v1/events/**",
+                                "/api/v1/teams/**",
+                                "/api/v1/artists/**"
                         ).permitAll()
                         .requestMatchers(
                                 "/**",
@@ -53,12 +74,13 @@ public class WebSecurityConfig {
                                 "/static/**",
                                 "/ws",
                                 "/api/v1/auth/signup",
+                                "/api/v1/auth/admin",
                                 "/api/v1/auth/login"
                         )
                         .permitAll()
                         .anyRequest().authenticated()
                 )
-        ;
+                .addFilterBefore(jwtTokenFilter, AuthorizationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
@@ -28,6 +28,7 @@ public class ArtistController {
     @PostMapping
     public ResponseEntity<ArtistDetailResponseDto> registerArtist(@RequestPart(name = "artist") ArtistRegisterDto requestDto,
                                                                   @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         ArtistDetailResponseDto responseDto = artistService.registerArtist(requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
@@ -37,6 +38,7 @@ public class ArtistController {
     public ResponseEntity<ArtistDetailResponseDto> updateArtist(@PathVariable Long artistId,
                                                                 @RequestPart(name = "artist") ArtistUpdateDto requestDto,
                                                                 @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         ArtistDetailResponseDto responseDto = artistService.updateArtist(artistId, requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -44,6 +46,7 @@ public class ArtistController {
     // 아티스트 삭제
     @DeleteMapping("/{artistId}")
     public ResponseEntity<Void> deleteArtist(@PathVariable Long artistId) {
+        String username = SecurityUtils.getCurrentUsername();
         artistService.delete(artistId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/ArtistController.java
@@ -8,6 +8,7 @@ import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.service.ArtistService;
+import com.happiday.Happi_Day.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ public class ArtistController {
     @PostMapping
     public ResponseEntity<ArtistDetailResponseDto> registerArtist(@RequestPart(name = "artist") ArtistRegisterDto requestDto,
                                                                   @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         ArtistDetailResponseDto responseDto = artistService.registerArtist(requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
@@ -34,12 +36,14 @@ public class ArtistController {
     public ResponseEntity<ArtistDetailResponseDto> updateArtist(@PathVariable Long artistId,
                                                                 @RequestPart(name = "artist") ArtistUpdateDto requestDto,
                                                                 @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         ArtistDetailResponseDto responseDto = artistService.updateArtist(artistId, requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @DeleteMapping("/{artistId}")
     public ResponseEntity<Void> deleteArtist(@PathVariable Long artistId) {
+        String username = SecurityUtils.getCurrentUsername();
         artistService.delete(artistId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
@@ -28,6 +28,7 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamDetailResponseDto> registerTeam(@RequestPart(name = "team") TeamRegisterDto requestDto,
                                                               @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         TeamDetailResponseDto responseDto = teamService.registerTeam(requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
@@ -37,6 +38,7 @@ public class TeamController {
     public ResponseEntity<TeamDetailResponseDto> updateTeam(@PathVariable Long teamId,
                                                             @RequestPart(name = "team") TeamUpdateDto requestDto,
                                                             @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         TeamDetailResponseDto responseDto = teamService.updateTeam(teamId, requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -44,6 +46,7 @@ public class TeamController {
     // 팀 삭제
     @DeleteMapping("/{teamId}")
     public ResponseEntity<Void> deleteTeam(@PathVariable Long teamId) {
+        String username = SecurityUtils.getCurrentUsername();
         teamService.deleteTeam(teamId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/TeamController.java
@@ -8,6 +8,7 @@ import com.happiday.Happi_Day.domain.entity.team.dto.TeamRegisterDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamDetailResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamUpdateDto;
 import com.happiday.Happi_Day.domain.service.TeamService;
+import com.happiday.Happi_Day.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ public class TeamController {
     @PostMapping
     public ResponseEntity<TeamDetailResponseDto> registerTeam(@RequestPart(name = "team") TeamRegisterDto requestDto,
                                                               @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         TeamDetailResponseDto responseDto = teamService.registerTeam(requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
@@ -34,12 +36,14 @@ public class TeamController {
     public ResponseEntity<TeamDetailResponseDto> updateTeam(@PathVariable Long teamId,
                                                             @RequestPart(name = "team") TeamUpdateDto requestDto,
                                                             @RequestPart(value = "file", required = false) MultipartFile imageFile) {
+        String username = SecurityUtils.getCurrentUsername();
         TeamDetailResponseDto responseDto = teamService.updateTeam(teamId, requestDto, imageFile);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @DeleteMapping("/{teamId}")
     public ResponseEntity<Void> deleteTeam(@PathVariable Long teamId) {
+        String username = SecurityUtils.getCurrentUsername();
         teamService.deleteTeam(teamId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/UserAuthController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/UserAuthController.java
@@ -68,4 +68,18 @@ public class UserAuthController {
         new SecurityContextLogoutHandler().logout(request, response, SecurityContextHolder.getContext().getAuthentication());
         return new ResponseEntity<>("로그아웃되었습니다.", HttpStatus.OK);
     }
+
+    @PostMapping("/admin")
+    public ResponseEntity<?> registerAdmin(@Validated @RequestBody UserRegisterDto dto) {
+        CustomUserDetails userDetails = CustomUserDetails.builder()
+                .username(dto.getUsername())
+                .password(passwordEncoder.encode(dto.getPassword()))
+                .nickname(dto.getNickname())
+                .realname(dto.getRealname())
+                .phone(dto.getPhone())
+                .role(RoleType.ADMIN)
+                .build();
+        manager.createUser(userDetails);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/UserController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/UserController.java
@@ -4,6 +4,8 @@ import com.happiday.Happi_Day.domain.entity.article.dto.ReadListArticleDto;
 import com.happiday.Happi_Day.domain.entity.article.dto.ReadListCommentDto;
 import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.event.dto.comment.EventCommentListResponseDto;
+import com.happiday.Happi_Day.domain.entity.product.dto.ReadListOrderDto;
+import com.happiday.Happi_Day.domain.entity.product.dto.ReadListSalesDto;
 import com.happiday.Happi_Day.domain.entity.user.dto.UserResponseDto;
 import com.happiday.Happi_Day.domain.entity.user.dto.UserUpdateDto;
 import com.happiday.Happi_Day.domain.service.MyPageService;
@@ -94,6 +96,18 @@ public class UserController {
     public ResponseEntity<Page<EventListResponseDto>> getJoinEvents(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         String username = SecurityUtils.getCurrentUsername();
         return new ResponseEntity<>(myPageService.readJoinEvents(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/sales")
+    public ResponseEntity<Page<ReadListSalesDto>> getMySales(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMySales(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/orders")
+    public ResponseEntity<Page<ReadListOrderDto>> getMyOrders(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMyOrders(username, pageable), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/UserController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/UserController.java
@@ -1,20 +1,30 @@
 package com.happiday.Happi_Day.domain.controller;
 
+import com.happiday.Happi_Day.domain.entity.article.dto.ReadListArticleDto;
+import com.happiday.Happi_Day.domain.entity.article.dto.ReadListCommentDto;
+import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
+import com.happiday.Happi_Day.domain.entity.event.dto.comment.EventCommentListResponseDto;
 import com.happiday.Happi_Day.domain.entity.user.dto.UserResponseDto;
 import com.happiday.Happi_Day.domain.entity.user.dto.UserUpdateDto;
+import com.happiday.Happi_Day.domain.service.MyPageService;
 import com.happiday.Happi_Day.domain.service.UserService;
 import com.happiday.Happi_Day.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/user")
 public class UserController {
 
     private final UserService userService;
+    private final MyPageService myPageService;
 
     @GetMapping("/info")
     public ResponseEntity<UserResponseDto> getUser() {
@@ -36,6 +46,54 @@ public class UserController {
         userService.deleteUser(username);
         return new ResponseEntity<>("회원탈퇴되었습니다.", HttpStatus.OK);
 
+    }
+
+    @GetMapping("/articles")
+    public ResponseEntity<Page<ReadListArticleDto>> getMyArticles(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMyArticles(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/articles/comments")
+    public ResponseEntity<Page<ReadListCommentDto>> getMyArticleComments(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMyArticleComments(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/articles/like")
+    public ResponseEntity<Page<ReadListArticleDto>> getLikeArticles(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readLikeArticles(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/articles/scrap")
+    public ResponseEntity<Page<ReadListArticleDto>> getScrapArticles(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readScrapArticles(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/events")
+    public ResponseEntity<Page<EventListResponseDto>> getMyEvents(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMyEvents(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/events/comments")
+    public ResponseEntity<Page<EventCommentListResponseDto>> getMyEventComments(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readMyEventComments(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/events/like")
+    public ResponseEntity<Page<EventListResponseDto>> getLikeEvents(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readLikeEvents(username, pageable), HttpStatus.OK);
+    }
+
+    @GetMapping("/events/join")
+    public ResponseEntity<Page<EventListResponseDto>> getJoinEvents(@PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        String username = SecurityUtils.getCurrentUsername();
+        return new ResponseEntity<>(myPageService.readJoinEvents(username, pageable), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/article/dto/ReadListCommentDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/article/dto/ReadListCommentDto.java
@@ -1,0 +1,26 @@
+package com.happiday.Happi_Day.domain.entity.article.dto;
+
+import com.happiday.Happi_Day.domain.entity.article.Article;
+import com.happiday.Happi_Day.domain.entity.article.ArticleComment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReadListCommentDto {
+    private Long id;
+    private String content;
+    private LocalDateTime createdAt;
+    private Article article;
+
+    public static ReadListCommentDto fromEntity(ArticleComment comment) {
+        return ReadListCommentDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .article(comment.getArticle())
+                .build();
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/article/dto/ReadListCommentDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/article/dto/ReadListCommentDto.java
@@ -13,14 +13,14 @@ public class ReadListCommentDto {
     private Long id;
     private String content;
     private LocalDateTime createdAt;
-    private Article article;
+    private Long articleId;
 
     public static ReadListCommentDto fromEntity(ArticleComment comment) {
         return ReadListCommentDto.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
-                .article(comment.getArticle())
+                .articleId(comment.getArticle().getId())
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/comment/EventCommentListResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/comment/EventCommentListResponseDto.java
@@ -14,14 +14,14 @@ public class EventCommentListResponseDto {
     private Long id;
     private String content;
     private LocalDateTime createdAt;
-    private Event event;
+    private Long eventId;
 
     public static EventCommentListResponseDto fromEntity(EventComment comment) {
         return EventCommentListResponseDto.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
-                .event(comment.getEvent())
+                .eventId(comment.getEvent().getId())
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/comment/EventCommentListResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/comment/EventCommentListResponseDto.java
@@ -1,0 +1,27 @@
+package com.happiday.Happi_Day.domain.entity.event.dto.comment;
+
+import com.happiday.Happi_Day.domain.entity.event.Event;
+import com.happiday.Happi_Day.domain.entity.event.EventComment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EventCommentListResponseDto {
+    private Long id;
+    private String content;
+    private LocalDateTime createdAt;
+    private Event event;
+
+    public static EventCommentListResponseDto fromEntity(EventComment comment) {
+        return EventCommentListResponseDto.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .event(comment.getEvent())
+                .build();
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadListOrderDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadListOrderDto.java
@@ -1,0 +1,28 @@
+package com.happiday.Happi_Day.domain.entity.product.dto;
+
+import com.happiday.Happi_Day.domain.entity.product.Order;
+import com.happiday.Happi_Day.domain.entity.product.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class ReadListOrderDto {
+    private Long id;
+    private String name;
+    private Integer price;
+    private OrderStatus orderStatus;
+    private String orderAt;
+
+    public static ReadListOrderDto fromEntity(Order order) {
+        return ReadListOrderDto.builder()
+                .id(order.getId())
+                .name(order.getSales().getName())
+                .price(order.getTotalPrice())
+                .orderStatus(order.getOrderStatus())
+                .orderAt(order.getOrderedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .build();
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/user/CustomUserDetails.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/user/CustomUserDetails.java
@@ -82,7 +82,7 @@ public class CustomUserDetails implements UserDetails {
                 .nickname(nickname)
                 .realname(realname)
                 .phone(phone)
-                .role(RoleType.USER)
+                .role(role)
                 .build();
 
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/user/User.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/user/User.java
@@ -15,6 +15,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -28,6 +30,8 @@ import java.util.List;
 @Table(name = "user")
 @EntityListeners(value = AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE user SET deleted_at = now() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,8 +59,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Boolean isActive;
 
-    private Boolean isDeleted = false;
-
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime lastLoginAt; // 마지막 로그인 날짜
 
@@ -64,7 +66,7 @@ public class User extends BaseEntity {
     @PrePersist
     public void prePersist() {
         this.isActive = this.isActive == null || this.isActive;
-        this.isDeleted = this.isDeleted != null && this.isDeleted;
+//        this.isDeleted = this.isDeleted != null && this.isDeleted;
     }
 
     // 게시글 작성 매핑(Article) => 커뮤니티(자유게시글)

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleCommentRepository.java
@@ -2,10 +2,13 @@ package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.article.Article;
 import com.happiday.Happi_Day.domain.entity.article.ArticleComment;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
     Page<ArticleComment> findAllByArticle(Article article, Pageable pageable);
+
+    Page<ArticleComment> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleRepository.java
@@ -2,10 +2,17 @@ package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.article.Article;
 import com.happiday.Happi_Day.domain.entity.board.BoardCategory;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findAllByCategory(BoardCategory category, Pageable pageable);
+
+    Page<Article> findAllByUser(User user, Pageable pageable);
+
+    Page<Article> findAllByLikeUsersContains(User user, Pageable pageable);
+
+    Page<Article> findAllByScrapUsersContains(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/EventCommentRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/EventCommentRepository.java
@@ -2,6 +2,7 @@ package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.event.Event;
 import com.happiday.Happi_Day.domain.entity.event.EventComment;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventCommentRepository extends JpaRepository<EventComment, Long> {
     Page<EventComment> findAllByEvent(Event event, Pageable pageable);
+
+    Page<EventComment> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/EventRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/EventRepository.java
@@ -1,7 +1,16 @@
 package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.event.Event;
+import com.happiday.Happi_Day.domain.entity.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    Page<Event> findAllByUser(User user, Pageable pageable);
+
+    Page<Event> findAllByLikesContains(User user, Pageable pageable);
+
+    Page<Event> findAllByJoinListContains(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/OrderRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.product.Order;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Page<Order> findAllBySales(Sales sales, Pageable pageable);
+
+    Page<Order> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/SalesRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/SalesRepository.java
@@ -2,6 +2,7 @@ package com.happiday.Happi_Day.domain.repository;
 
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesCategory;
+import com.happiday.Happi_Day.domain.entity.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import java.util.List;
 
 public interface SalesRepository extends JpaRepository<Sales, Long> {
     Page<Sales> findAllBySalesCategory(SalesCategory category, Pageable pageable);
+
+    Page<Sales> findAllByUsers(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/JpaUserDetailsManager.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/JpaUserDetailsManager.java
@@ -23,7 +23,7 @@ public class JpaUserDetailsManager implements UserDetailsManager {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return CustomUserDetails.fromEntity(user);
     }
 
@@ -35,7 +35,7 @@ public class JpaUserDetailsManager implements UserDetailsManager {
     @Override
     public void createUser(UserDetails user) {
         if (this.userExists(user.getUsername()))
-            throw new ResponseStatusException(HttpStatus.CONFLICT);
+            throw new CustomException(ErrorCode.USER_CONFLICT);
         userRepository.save(((CustomUserDetails) user).newEntity());
     }
 

--- a/src/main/java/com/happiday/Happi_Day/domain/service/MyPageService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/MyPageService.java
@@ -8,6 +8,9 @@ import com.happiday.Happi_Day.domain.entity.event.Event;
 import com.happiday.Happi_Day.domain.entity.event.EventComment;
 import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.event.dto.comment.EventCommentListResponseDto;
+import com.happiday.Happi_Day.domain.entity.product.Order;
+import com.happiday.Happi_Day.domain.entity.product.Sales;
+import com.happiday.Happi_Day.domain.entity.product.dto.*;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
@@ -27,6 +30,8 @@ public class MyPageService {
     private final ArticleCommentRepository articleCommentRepository;
     private final EventRepository eventRepository;
     private final EventCommentRepository eventCommentRepository;
+    private final SalesRepository salesRepository;
+    private final OrderRepository orderRepository;
     private final UserRepository userRepository;
 
     public Page<ReadListArticleDto> readMyArticles(String username, Pageable pageable) {
@@ -83,5 +88,19 @@ public class MyPageService {
         Page<Event> events = eventRepository.findAllByJoinListContains(user, pageable);
 
         return events.map(EventListResponseDto::fromEntity);
+    }
+
+    public Page<ReadListSalesDto> readMySales(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Sales> sales = salesRepository.findAllByUsers(user, pageable);
+
+        return sales.map(ReadListSalesDto::fromEntity);
+    }
+
+    public Page<ReadListOrderDto> readMyOrders(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Order> orders = orderRepository.findAllByUser(user, pageable);
+
+        return orders.map(ReadListOrderDto::fromEntity);
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/MyPageService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/MyPageService.java
@@ -1,0 +1,87 @@
+package com.happiday.Happi_Day.domain.service;
+
+import com.happiday.Happi_Day.domain.entity.article.Article;
+import com.happiday.Happi_Day.domain.entity.article.ArticleComment;
+import com.happiday.Happi_Day.domain.entity.article.dto.ReadListArticleDto;
+import com.happiday.Happi_Day.domain.entity.article.dto.ReadListCommentDto;
+import com.happiday.Happi_Day.domain.entity.event.Event;
+import com.happiday.Happi_Day.domain.entity.event.EventComment;
+import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
+import com.happiday.Happi_Day.domain.entity.event.dto.comment.EventCommentListResponseDto;
+import com.happiday.Happi_Day.domain.entity.user.User;
+import com.happiday.Happi_Day.domain.repository.*;
+import com.happiday.Happi_Day.exception.CustomException;
+import com.happiday.Happi_Day.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
+    private final EventRepository eventRepository;
+    private final EventCommentRepository eventCommentRepository;
+    private final UserRepository userRepository;
+
+    public Page<ReadListArticleDto> readMyArticles(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Article> articles = articleRepository.findAllByUser(user, pageable);
+
+        return articles.map(ReadListArticleDto::fromEntity);
+    }
+
+    public Page<ReadListCommentDto> readMyArticleComments(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<ArticleComment> articleComments = articleCommentRepository.findAllByUser(user, pageable);
+
+        return articleComments.map(ReadListCommentDto::fromEntity);
+    }
+
+    public Page<ReadListArticleDto> readLikeArticles(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Article> articles = articleRepository.findAllByLikeUsersContains(user, pageable);
+
+        return articles.map(ReadListArticleDto::fromEntity);
+    }
+
+    public Page<ReadListArticleDto> readScrapArticles(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Article> articles = articleRepository.findAllByScrapUsersContains(user, pageable);
+
+        return articles.map(ReadListArticleDto::fromEntity);
+    }
+
+    public Page<EventListResponseDto> readMyEvents(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Event> events = eventRepository.findAllByUser(user, pageable);
+
+        return events.map(EventListResponseDto::fromEntity);
+    }
+
+    public Page<EventCommentListResponseDto> readMyEventComments(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<EventComment> eventComments = eventCommentRepository.findAllByUser(user, pageable);
+
+        return eventComments.map(EventCommentListResponseDto::fromEntity);
+    }
+
+    public Page<EventListResponseDto> readLikeEvents(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Event> events = eventRepository.findAllByLikesContains(user, pageable);
+
+        return events.map(EventListResponseDto::fromEntity);
+    }
+
+    public Page<EventListResponseDto> readJoinEvents(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Page<Event> events = eventRepository.findAllByJoinListContains(user, pageable);
+
+        return events.map(EventListResponseDto::fromEntity);
+    }
+}

--- a/src/main/java/com/happiday/Happi_Day/exception/ErrorCode.java
+++ b/src/main/java/com/happiday/Happi_Day/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
 
     // user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    USER_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 유저입니다."),
     PASSWORD_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
 
     // chat


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [x] 병합되는 브랜치가 Develop인지 확인
- [x] 기능 수정 시에 테스트 코드 수정 확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 이슈 연동 확인
- [x] 커밋 메시지, 브랜치명 컨벤션 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #131
close #131 

## 🎯 변경 사항 요약
- 유저, 어드민 기능 추가

## 📣 변경 사항 상세
- [x] 유저 소프트 딜리트 적용
- [x] 어드민 권한 설정
- [x] 마이페이지 기능 추가


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
수민
- Article 엔티티에는 scrap 이 있는데 컨트롤러에는 없어서 확인 부탁드립니다.
- 포스트맨에 있는 배송방법 생성 조회 삭제 이거는 안쓰는건가요??

용준
- 이벤트 상세조회에 댓글 수, 좋아요 수, 참여 수 같은거 나오면 어떨까요?

도영
- 아티스트,팀 상세조회가 인증가능해야 볼 수 있는데 인증이 필요한 이유가 몬가요?

수민&용준
- 이벤트 조회할 때는 updatedAt, 게시글 조회할 때는 createdAt 으로 뜨고
- 게시글 댓글 작성할 때는 /api/v1/articleComments/1, 이벤트 댓글 작성할 때는 /api/v1/events/1/comments 인데
→ 이거를 하나로 통일해야되지 않을까 싶습니다

