### PR TITLE
[Feature] 팀/아티스트 조회 시 관련 상품 및 이벤트가 조회되도록 기능 추가

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistDetailResponseDto.java
@@ -1,6 +1,8 @@
 package com.happiday.Happi_Day.domain.entity.artist.dto;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
+import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,8 @@ public class ArtistDetailResponseDto {
     private String profileUrl;
     private boolean isSubscribed;
     private List<TeamListResponseDto> teams;
+    private List<SalesListResponseDto> sales;
+    private List<EventListResponseDto> events;
 
     public static ArtistDetailResponseDto of(Artist artist, boolean isSubscribed) {
         return ArtistDetailResponseDto.builder()
@@ -35,6 +39,24 @@ public class ArtistDetailResponseDto {
                 .profileUrl(artist.getProfileUrl())
                 .isSubscribed(isSubscribed)
                 .teams(teams)
+                .build();
+    }
+
+    public static ArtistDetailResponseDto of(
+            Artist artist,
+            boolean isSubscribed,
+            List<TeamListResponseDto> teams,
+            List<SalesListResponseDto> sales,
+            List<EventListResponseDto> events) {
+        return ArtistDetailResponseDto.builder()
+                .id(artist.getId())
+                .name(artist.getName())
+                .description(artist.getDescription())
+                .profileUrl(artist.getProfileUrl())
+                .isSubscribed(isSubscribed)
+                .teams(teams)
+                .sales(sales)
+                .events(events)
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/team/dto/TeamDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/team/dto/TeamDetailResponseDto.java
@@ -1,6 +1,8 @@
 package com.happiday.Happi_Day.domain.entity.team.dto;
 
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
+import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
+import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,8 @@ public class TeamDetailResponseDto {
     private String logoUrl;
     private boolean isSubscribed;
     private List<ArtistListResponseDto> artists;
+    private List<SalesListResponseDto> sales;
+    private List<EventListResponseDto> events;
 
     public static TeamDetailResponseDto of(Team team, boolean isSubscribed) {
         return TeamDetailResponseDto.builder()
@@ -35,6 +39,24 @@ public class TeamDetailResponseDto {
                 .logoUrl(team.getLogoUrl())
                 .isSubscribed(isSubscribed)
                 .artists(artists)
+                .build();
+    }
+
+    public static TeamDetailResponseDto of(
+            Team team,
+            boolean isSubscribed,
+            List<ArtistListResponseDto> artists,
+            List<SalesListResponseDto> sales,
+            List<EventListResponseDto> events) {
+        return TeamDetailResponseDto.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .logoUrl(team.getLogoUrl())
+                .isSubscribed(isSubscribed)
+                .artists(artists)
+                .sales(sales)
+                .events(events)
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArticleRepository.java
@@ -13,6 +13,4 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findAllByUser(User user, Pageable pageable);
 
     Page<Article> findAllByLikeUsersContains(User user, Pageable pageable);
-
-    Page<Article> findAllByScrapUsersContains(User user, Pageable pageable);
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
@@ -127,7 +127,17 @@ public class ArtistService {
                 .map(TeamListResponseDto::of)
                 .collect(Collectors.toList());
 
-        return ArtistDetailResponseDto.of(artist, isSubscribed, teams);
+        // 관련 상품 조회
+        List<SalesListResponseDto> sales = artist.getSalesList().stream()
+                .map(SalesListResponseDto::of)
+                .collect(Collectors.toList());
+
+        // 관련 이벤트 조회
+        List<EventListResponseDto> events = artist.getEvents().stream()
+                .map(EventListResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return ArtistDetailResponseDto.of(artist, isSubscribed, teams, sales, events);
     }
 
     // 아티스트 목록 조회

--- a/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
@@ -102,11 +102,23 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
         boolean isSubscribed = user.getSubscribedTeams().contains(team);
+
         // 팀에 소속된 아티스트 정보 가져오기
         List<ArtistListResponseDto> artists = team.getArtists().stream()
                 .map(ArtistListResponseDto::of)
                 .collect(Collectors.toList());
-        return TeamDetailResponseDto.of(team, isSubscribed, artists);
+
+        // 관련 상품 조회
+        List<SalesListResponseDto> sales = team.getSalesList().stream()
+                .map(SalesListResponseDto::of)
+                .collect(Collectors.toList());
+
+        // 관련 이벤트 조회
+        List<EventListResponseDto> events = team.getEvents().stream()
+                .map(EventListResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        return TeamDetailResponseDto.of(team, isSubscribed, artists, sales, events);
     }
 
     // 팀 목록 조회


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [x] 커밋 메시지, 브랜치명 컨벤션 확인
- [x] 병합되는 브랜치가 Develop인지 확인
- [x] 기능 수정 시에 테스트 코드 수정 확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 이슈 연동 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #144 
close #144 

## 🎯 변경 사항 요약
- 팀/아티스트 조회 시 관련 상품 및 이벤트가 조회되도록 기능 추가

## 📣 변경 사항 상세
- [x] 팀/아티스트 상세 조회 시, 관련 상품이 함께 List로 조회
- [x] 팀/아티스트 상세 조회 시, 관련 이벤트가 함께 List로 조회
- [x] 게시글의 scrapUser가 없어짐에 따른 repository 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
