### PR TITLE
[Feature] 이벤트 리스트 필터 조회 추가

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
+++ b/src/main/java/com/happiday/Happi_Day/config/WebSecurityConfig.java
@@ -68,6 +68,10 @@ public class WebSecurityConfig {
                                 "/api/v1/artists/**"
                         ).permitAll()
                         .requestMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/event/subscribedArtists/**"
+                        ).authenticated()
+                        .requestMatchers(
                                 "/**",
                                 "/error",
                                 "/views/**",

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
@@ -92,15 +92,17 @@ public class EventController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-//    @GetMapping()
-//    public ResponseEntity<Page<EventListResponseDto>> readEventsByArtist(
-//            @RequestParam(name = "artistIds", required = false) List<Long> artistIds,
-//            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
-//
-//    ){
-//        Page<EventListResponseDto> responseDtoList = eventService.readEventsByArtists(artistIds, pageable);
-//        log.info("내가 좋아요한 아티스트 관련 이벤트 리스트 조회");
-//        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
-//    }
+    @GetMapping()
+    public ResponseEntity<Page<EventListResponseDto>> readEventsByArtist(
+            @RequestParam(name = "artistIds", required = false) List<Long> artistIds,
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false) String keyword
+
+    ){
+        Page<EventListResponseDto> responseDtoList = eventService.readEventsByArtists(artistIds, pageable, filter, keyword);
+        log.info("내가 좋아요한 아티스트 관련 이벤트 리스트 조회");
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
@@ -92,15 +92,15 @@ public class EventController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping()
-    public ResponseEntity<Page<EventListResponseDto>> readEventsByArtist(
-            @RequestParam(name = "artistIds", required = false) List<Long> artistIds,
+    @GetMapping("/artists")
+    public ResponseEntity<Page<EventListResponseDto>> readEventsBySubscribeArtist(
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) String filter,
             @RequestParam(required = false) String keyword
 
     ){
-        Page<EventListResponseDto> responseDtoList = eventService.readEventsByArtists(artistIds, pageable, filter, keyword);
+        String username = SecurityUtils.getCurrentUsername();
+        Page<EventListResponseDto> responseDtoList = eventService.readEventsByArtists(username, pageable, filter, keyword);
         log.info("내가 좋아요한 아티스트 관련 이벤트 리스트 조회");
         return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/controller/EventController.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
 
 
 @Slf4j
@@ -53,9 +52,52 @@ public class EventController {
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) String filter,
             @RequestParam(required = false) String keyword
+
     ){
+
         Page<EventListResponseDto> responseDtoList = eventService.readEvents(pageable, filter, keyword);
         log.info("이벤트 리스트 조회");
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+    }
+
+    @GetMapping("/ongoing")
+    public ResponseEntity<Page<EventListResponseDto>> readOngoingEvents(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false) String keyword
+
+    ){
+
+        Page<EventListResponseDto> responseDtoList = eventService.readOngoingEvents(pageable, filter, keyword);
+        log.info("진행 중인 이벤트 리스트 조회");
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+    }
+
+    @GetMapping("/subscribedArtists")
+    public ResponseEntity<Page<EventListResponseDto>> readEventsBySubscribedArtists(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false) String keyword
+
+    ){
+        String username = SecurityUtils.getCurrentUsername();
+
+        Page<EventListResponseDto> responseDtoList = eventService.readEventsBySubscribedArtists(pageable, filter, keyword, username);
+        log.info("내가 구독한 아티스트/팀의 이벤트 리스트 조회");
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+    }
+
+    @GetMapping("/subscribedArtists/ongoing")
+    public ResponseEntity<Page<EventListResponseDto>> readOngoingEventsBySubscribedArtists(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false) String keyword
+
+    ){
+        String username = SecurityUtils.getCurrentUsername();
+
+        Page<EventListResponseDto> responseDtoList = eventService.readOngoingEventsBySubscribedArtists(pageable, filter, keyword, username);
+        log.info("내가 구독한 아티스트/팀의 진행중인 이벤트 리스트 조회");
         return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }
 
@@ -92,17 +134,5 @@ public class EventController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping("/artists")
-    public ResponseEntity<Page<EventListResponseDto>> readEventsBySubscribeArtist(
-            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
-            @RequestParam(required = false) String filter,
-            @RequestParam(required = false) String keyword
-
-    ){
-        String username = SecurityUtils.getCurrentUsername();
-        Page<EventListResponseDto> responseDtoList = eventService.readEventsByArtists(username, pageable, filter, keyword);
-        log.info("내가 좋아요한 아티스트 관련 이벤트 리스트 조회");
-        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
-    }
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/article/Hashtag.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/article/Hashtag.java
@@ -1,5 +1,6 @@
 package com.happiday.Happi_Day.domain.entity.article;
 
+import com.happiday.Happi_Day.domain.entity.event.Event;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -30,4 +31,7 @@ public class Hashtag {
 
     @ManyToMany(mappedBy = "hashtags")
     private List<Sales> sales = new ArrayList<>();
+
+    @ManyToMany(mappedBy = "hashtags")
+    private List<Event> events = new ArrayList<>();
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/Event.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/Event.java
@@ -1,6 +1,7 @@
 package com.happiday.Happi_Day.domain.entity.event;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
+import com.happiday.Happi_Day.domain.entity.article.Hashtag;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import com.happiday.Happi_Day.domain.entity.user.User;
@@ -88,11 +89,14 @@ public class Event extends BaseEntity {
     )
     private List<Artist> artists = new ArrayList<>();
 
-    @Column
-    private String ectTeams;
-
-    @Column
-    private String ectArtists;
+    // 이벤트 해시태그 매핑
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(
+            name = "event_hashtag",
+            joinColumns = @JoinColumn(name = "article_id"),
+            inverseJoinColumns = @JoinColumn(name = "hashtag_id")
+    )
+    private List<Hashtag> hashtags = new ArrayList<>();
 
 
 
@@ -124,13 +128,9 @@ public class Event extends BaseEntity {
             this.artists.clear();
             this.artists = updateEvent.getArtists();
         }
-        if (updateEvent.getEctArtists() != null) {
-            log.info("아티스트 + : " + updateEvent.getEctArtists());
-            this.ectArtists = updateEvent.getEctArtists();
-        }
-        if (updateEvent.getEctTeams() != null) {
-            log.info("팀 + : " + updateEvent.getEctTeams());
-            this.ectTeams = updateEvent.getEctTeams();
+        if (updateEvent.getHashtags() != null && !updateEvent.getHashtags().isEmpty()) {
+            this.hashtags.clear();
+            this.hashtags = updateEvent.getHashtags();
         }
     }
 

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/EventStatus.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/EventStatus.java
@@ -1,0 +1,7 @@
+package com.happiday.Happi_Day.domain.entity.event;
+
+public enum EventStatus {
+    SCHEDULED,
+    ONGOING,
+    FINISHED
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/EventStatus.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/EventStatus.java
@@ -1,7 +1,0 @@
-package com.happiday.Happi_Day.domain.entity.event;
-
-public enum EventStatus {
-    SCHEDULED,
-    ONGOING,
-    FINISHED
-}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventCreateDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventCreateDto.java
@@ -7,6 +7,7 @@ import com.happiday.Happi_Day.domain.repository.ArtistRepository;
 import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
@@ -22,15 +23,14 @@ public class EventCreateDto {
     public EventCreateDto() {
     }
 
-    public EventCreateDto(String title, LocalDateTime startTime, LocalDateTime endTime, String description, String address, String location, List<String> artists, List<String> teams) {
+    public EventCreateDto(String title, LocalDateTime startTime, LocalDateTime endTime, String description, String address, String location, List<String> hashtags) {
         this.title = title;
         this.startTime = startTime;
         this.endTime = endTime;
         this.description = description;
         this.address = address;
         this.location = location;
-        this.artists = artists;
-        this.teams = teams;
+        this.hashtags = hashtags;
     }
 
     @NotBlank(message = "제목을 입력해주세요.")
@@ -51,8 +51,7 @@ public class EventCreateDto {
     @NotBlank(message = "장소를 입력해주세요.")
     private String location;
 
-    private List<String> artists;
-
-    private List<String> teams;
+    @NotEmpty(message = "해시태그를 입력해주세요.")
+    private List<String> hashtags;
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventListResponse2Dto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventListResponse2Dto.java
@@ -1,0 +1,109 @@
+//package com.happiday.Happi_Day.domain.entity.event.dto;
+//
+//import com.happiday.Happi_Day.domain.entity.artist.Artist;
+//import com.happiday.Happi_Day.domain.entity.event.Event;
+//import com.happiday.Happi_Day.domain.entity.team.Team;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.Setter;
+//
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//
+//@Getter
+//@Setter
+//@Builder
+//public class EventListResponse2Dto {
+//    private Long id;
+//
+//    private String nickname;
+//
+//    private String title;
+//
+//    private LocalDateTime updatedAt;
+//
+//    private LocalDateTime startTime;
+//
+//    private LocalDateTime endTime;
+//
+//    private String location;
+//
+//    private String thumbnailUrl;
+//
+//    private String ectArtists;
+//
+//    private String ectTeams;
+//
+//    private List<String> artists;
+//
+//    private List<String> teams;
+//
+//    private int commentCount;
+//
+//    private int likeCount;
+//
+//    public EventListResponse2Dto() {
+//    }
+//
+////    @QueryProjection
+//    public EventListResponse2Dto(Long id, String nickname, String title, LocalDateTime updatedAt, LocalDateTime startTime, LocalDateTime endTime, String location, String thumbnailUrl, String ectArtists, String ectTeams, List<String> artists, List<String> teams, int commentCount, int likeCount) {
+//        this.id = id;
+//        this.nickname = nickname;
+//        this.title = title;
+//        this.updatedAt = updatedAt;
+//        this.startTime = startTime;
+//        this.endTime = endTime;
+//        this.location = location;
+//        this.thumbnailUrl = thumbnailUrl;
+//        this.ectArtists = ectArtists;
+//        this.ectTeams = ectTeams;
+//        this.artists = artists;
+//        this.teams = teams;
+//        this.commentCount = commentCount;
+//        this.likeCount = likeCount;
+//
+//    }
+//
+//    public static EventListResponse2Dto fromEntity(Event event) {
+//        // 이벤트의 artists 필드에서 이름을 꺼내오기
+//        List<String> eventArtists = event.getArtists().stream().map(Artist::getName).collect(Collectors.toList());
+//
+//        // 이벤트의 ectArtists 필드가 null이 아닌 경우, 추가 아티스트들을 쉼표(,)로 분리하여 리스트로 만들기
+//        List<String> additionalArtists = event.getEctArtists() != null ?
+//                Arrays.asList(event.getEctArtists().split(", ")) : Collections.emptyList();
+//
+//        // eventArtists와 additionalArtists를 합친 리스트 생성
+//        List<String> allArtists = new ArrayList<>(eventArtists);
+//        allArtists.addAll(additionalArtists);
+//
+//        // 이벤트의 teams 필드에서 이름을 꺼내오기
+//        List<String> eventTeams = event.getTeams().stream().map(Team::getName).collect(Collectors.toList());
+//
+//        // 이벤트의 ectTeams 필드가 null이 아닌 경우, 추가 팀들을 쉼표(,)로 분리하여 리스트로 만들기
+//        List<String> additionalTeams = event.getEctTeams() != null ?
+//                Arrays.asList(event.getEctTeams().split(", ")) : Collections.emptyList();
+//
+//        // eventTeams와 additionalTeams를 합친 리스트 생성
+//        List<String> allTeams = new ArrayList<>(eventTeams);
+//        allTeams.addAll(additionalTeams);
+//
+//        return EventListResponse2Dto.builder()
+//                .id(event.getId())
+//                .nickname(event.getUser().getNickname())
+//                .title(event.getTitle())
+//                .updatedAt(event.getUpdatedAt())
+//                .startTime(event.getStartTime())
+//                .endTime(event.getEndTime())
+//                .location(event.getLocation())
+//                .thumbnailUrl(event.getThumbnailUrl())
+//                .artists(allArtists)
+//                .teams(allTeams)
+//                .commentCount(event.getComments().size())
+//                .likeCount(event.getLikes().size())
+//                .build();
+//    }
+//}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventListResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventListResponseDto.java
@@ -1,5 +1,6 @@
 package com.happiday.Happi_Day.domain.entity.event.dto;
 
+import com.happiday.Happi_Day.domain.entity.article.Hashtag;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.event.Event;
 import com.happiday.Happi_Day.domain.entity.team.Team;
@@ -35,13 +36,11 @@ public class EventListResponseDto {
 
     private String thumbnailUrl;
 
-    private String ectArtists;
-
-    private String ectTeams;
-
     private List<String> artists;
 
     private List<String> teams;
+
+    private List<String> hashtags;
 
     private int commentCount;
 
@@ -51,7 +50,7 @@ public class EventListResponseDto {
     }
 
 //    @QueryProjection
-    public EventListResponseDto(Long id, String nickname, String title, LocalDateTime updatedAt, LocalDateTime startTime, LocalDateTime endTime, String location, String thumbnailUrl, String ectArtists, String ectTeams, List<String> artists, List<String> teams, int commentCount, int likeCount) {
+    public EventListResponseDto(Long id, String nickname, String title, LocalDateTime updatedAt, LocalDateTime startTime, LocalDateTime endTime, String location, String thumbnailUrl, List<String> artists, List<String> teams, List<String> hashtags, int commentCount, int likeCount) {
         this.id = id;
         this.nickname = nickname;
         this.title = title;
@@ -60,38 +59,15 @@ public class EventListResponseDto {
         this.endTime = endTime;
         this.location = location;
         this.thumbnailUrl = thumbnailUrl;
-        this.ectArtists = ectArtists;
-        this.ectTeams = ectTeams;
         this.artists = artists;
         this.teams = teams;
+        this.hashtags = hashtags;
         this.commentCount = commentCount;
         this.likeCount = likeCount;
 
     }
 
     public static EventListResponseDto fromEntity(Event event) {
-        // 이벤트의 artists 필드에서 이름을 꺼내오기
-        List<String> eventArtists = event.getArtists().stream().map(Artist::getName).collect(Collectors.toList());
-
-        // 이벤트의 ectArtists 필드가 null이 아닌 경우, 추가 아티스트들을 쉼표(,)로 분리하여 리스트로 만들기
-        List<String> additionalArtists = event.getEctArtists() != null ?
-                Arrays.asList(event.getEctArtists().split(", ")) : Collections.emptyList();
-
-        // eventArtists와 additionalArtists를 합친 리스트 생성
-        List<String> allArtists = new ArrayList<>(eventArtists);
-        allArtists.addAll(additionalArtists);
-
-        // 이벤트의 teams 필드에서 이름을 꺼내오기
-        List<String> eventTeams = event.getTeams().stream().map(Team::getName).collect(Collectors.toList());
-
-        // 이벤트의 ectTeams 필드가 null이 아닌 경우, 추가 팀들을 쉼표(,)로 분리하여 리스트로 만들기
-        List<String> additionalTeams = event.getEctTeams() != null ?
-                Arrays.asList(event.getEctTeams().split(", ")) : Collections.emptyList();
-
-        // eventTeams와 additionalTeams를 합친 리스트 생성
-        List<String> allTeams = new ArrayList<>(eventTeams);
-        allTeams.addAll(additionalTeams);
-
         return EventListResponseDto.builder()
                 .id(event.getId())
                 .nickname(event.getUser().getNickname())
@@ -101,8 +77,9 @@ public class EventListResponseDto {
                 .endTime(event.getEndTime())
                 .location(event.getLocation())
                 .thumbnailUrl(event.getThumbnailUrl())
-                .artists(allArtists)
-                .teams(allTeams)
+                .artists(event.getArtists().stream().map(Artist::getName).collect(Collectors.toList()))
+                .teams(event.getTeams().stream().map(Team::getName).collect(Collectors.toList()))
+                .hashtags(event.getHashtags().stream().map(Hashtag::getTag).collect(Collectors.toList()))
                 .commentCount(event.getComments().size())
                 .likeCount(event.getLikes().size())
                 .build();

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventResponse2Dto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventResponse2Dto.java
@@ -1,0 +1,95 @@
+//package com.happiday.Happi_Day.domain.entity.event.dto;
+//
+//import com.happiday.Happi_Day.domain.entity.artist.Artist;
+//import com.happiday.Happi_Day.domain.entity.event.Event;
+//import com.happiday.Happi_Day.domain.entity.team.Team;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.Setter;
+//
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//
+//@Getter
+//@Setter
+//@Builder
+//public class EventResponse2Dto {
+//
+//    private Long id;
+//
+//    private String username;
+//
+//    private String title;
+//
+//    private LocalDateTime updatedAt;
+//
+//    private LocalDateTime startTime;
+//
+//    private LocalDateTime endTime;
+//
+//    private String description;
+//
+//    private String address;
+//
+//    private String location;
+//
+//    private String thumbnailUrl;
+//
+//    private String imageUrl;
+//
+//    private List<String> artists;
+//
+//    private List<String> teams;
+//
+//    private int commentCount;
+//
+//    private int likeCount;
+//
+//    private int joinCount;
+//
+//
+//    public static EventResponse2Dto fromEntity(Event event) {
+//        // 이벤트의 artists 필드에서 이름을 꺼내오기
+//        List<String> eventArtists = event.getArtists().stream().map(Artist::getName).collect(Collectors.toList());
+//
+//        // 이벤트의 ectArtists 필드가 null이 아닌 경우, 추가 아티스트들을 쉼표(,)로 분리하여 리스트로 만들기
+//        List<String> additionalArtists = event.getEctArtists() != null ? Arrays.asList(event.getEctArtists().split(", ")) : Collections.emptyList();
+//
+//        // eventArtists와 additionalArtists를 합친 리스트 생성
+//        List<String> allArtists = new ArrayList<>(eventArtists);
+//        allArtists.addAll(additionalArtists);
+//
+//        // 이벤트의 teams 필드에서 이름을 꺼내오기
+//        List<String> eventTeams = event.getTeams().stream().map(Team::getName).collect(Collectors.toList());
+//
+//        // 이벤트의 ectTeams 필드가 null이 아닌 경우, 추가 팀들을 쉼표(,)로 분리하여 리스트로 만들기
+//        List<String> additionalTeams = event.getEctTeams() != null ? Arrays.asList(event.getEctTeams().split(", ")) : Collections.emptyList();
+//
+//        // eventTeams와 additionalTeams를 합친 리스트 생성
+//        List<String> allTeams = new ArrayList<>(eventTeams);
+//        allTeams.addAll(additionalTeams);
+//
+//        return EventResponse2Dto.builder()
+//                .id(event.getId())
+//                .username(event.getUser().getNickname())
+//                .title(event.getTitle())
+//                .updatedAt(event.getUpdatedAt())
+//                .startTime(event.getStartTime())
+//                .endTime(event.getEndTime())
+//                .description(event.getDescription())
+//                .address(event.getAddress())
+//                .location(event.getLocation())
+//                .thumbnailUrl(event.getThumbnailUrl())
+//                .imageUrl(event.getImageUrl())
+//                .artists(allArtists)
+//                .teams(allTeams)
+//                .commentCount(event.getCommentCount())
+//                .joinCount(event.getJoinCount())
+//                .likeCount(event.getLikeCount())
+//                .build();
+//    }
+//}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventResponseDto.java
@@ -1,5 +1,6 @@
 package com.happiday.Happi_Day.domain.entity.event.dto;
 
+import com.happiday.Happi_Day.domain.entity.article.Hashtag;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.event.Event;
 import com.happiday.Happi_Day.domain.entity.team.Team;
@@ -43,6 +44,8 @@ public class EventResponseDto {
 
     private List<String> teams;
 
+    private List<String> hashtags;
+
     private int commentCount;
 
     private int likeCount;
@@ -51,26 +54,6 @@ public class EventResponseDto {
 
 
     public static EventResponseDto fromEntity(Event event) {
-        // 이벤트의 artists 필드에서 이름을 꺼내오기
-        List<String> eventArtists = event.getArtists().stream().map(Artist::getName).collect(Collectors.toList());
-
-        // 이벤트의 ectArtists 필드가 null이 아닌 경우, 추가 아티스트들을 쉼표(,)로 분리하여 리스트로 만들기
-        List<String> additionalArtists = event.getEctArtists() != null ? Arrays.asList(event.getEctArtists().split(", ")) : Collections.emptyList();
-
-        // eventArtists와 additionalArtists를 합친 리스트 생성
-        List<String> allArtists = new ArrayList<>(eventArtists);
-        allArtists.addAll(additionalArtists);
-
-        // 이벤트의 teams 필드에서 이름을 꺼내오기
-        List<String> eventTeams = event.getTeams().stream().map(Team::getName).collect(Collectors.toList());
-
-        // 이벤트의 ectTeams 필드가 null이 아닌 경우, 추가 팀들을 쉼표(,)로 분리하여 리스트로 만들기
-        List<String> additionalTeams = event.getEctTeams() != null ? Arrays.asList(event.getEctTeams().split(", ")) : Collections.emptyList();
-
-        // eventTeams와 additionalTeams를 합친 리스트 생성
-        List<String> allTeams = new ArrayList<>(eventTeams);
-        allTeams.addAll(additionalTeams);
-
         return EventResponseDto.builder()
                 .id(event.getId())
                 .username(event.getUser().getNickname())
@@ -83,8 +66,9 @@ public class EventResponseDto {
                 .location(event.getLocation())
                 .thumbnailUrl(event.getThumbnailUrl())
                 .imageUrl(event.getImageUrl())
-                .artists(allArtists)
-                .teams(allTeams)
+                .artists(event.getArtists().stream().map(Artist::getName).collect(Collectors.toList()))
+                .teams(event.getTeams().stream().map(Team::getName).collect(Collectors.toList()))
+                .hashtags(event.getHashtags().stream().map(Hashtag::getTag).collect(Collectors.toList()))
                 .commentCount(event.getCommentCount())
                 .joinCount(event.getJoinCount())
                 .likeCount(event.getLikeCount())

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventUpdateDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/event/dto/EventUpdateDto.java
@@ -18,7 +18,7 @@ public class EventUpdateDto {
 
     public EventUpdateDto() {
     }
-    public EventUpdateDto(String title, LocalDateTime startTime, LocalDateTime endTime, String description, String address, String location, String thumbnailUrl, String imageUrl, List<String> artists, List<String> teams) {
+    public EventUpdateDto(String title, LocalDateTime startTime, LocalDateTime endTime, String description, String address, String location, String thumbnailUrl, String imageUrl, List<String> hashtags) {
         this.title = title;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -27,8 +27,7 @@ public class EventUpdateDto {
         this.location = location;
         this.thumbnailUrl = thumbnailUrl;
         this.imageUrl = imageUrl;
-        this.artists = artists;
-        this.teams = teams;
+        this.hashtags = hashtags;
     }
 
     private String title;
@@ -47,8 +46,6 @@ public class EventUpdateDto {
 
     private String imageUrl;
 
-    private List<String> artists;
-
-    private List<String> teams;
+    private List<String> hashtags;
 
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/EventService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/EventService.java
@@ -275,4 +275,13 @@ public class EventService {
         return event.getTitle() + response;
     }
 
+    public Page<EventListResponseDto> readEventsByArtists(String username, Pageable pageable, String filter, String keyword) {
+        userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        log.info("이벤트 리스트 조회");
+        Page<Event> events = queryRepository.findEventsByArtist(username, pageable, filter, keyword);
+
+        return events.map(EventListResponseDto::fromEntity);
+    }
 }


### PR DESCRIPTION
## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [x] 커밋 메시지, 브랜치명 컨벤션 확인
- [x] 병합되는 브랜치가 Develop인지 확인
- [x] 기능 수정 시에 테스트 코드 수정 확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 이슈 연동 확인

## 🔗 이슈 연동
Linked Issue Number : #151 
close : #151 

## 🎯 변경 사항 요약
- EventStatus 클래스 삭제
- EventEntity 컬럼 수정
- EventEntity 매핑 추가
- Event 필터링 조회 추가

## 📣 변경 사항 상세
- [x] EventStatus 클래스 삭제
- [x] EventEntity ectArtists, ectTeams 컬럼 삭제
- [x] EventEntity Hashtag 매핑 추가
- [ ] 구독한 아티스트/팀 이벤트 목록 조회(안됩니다....)
- [x] 진행 중인 이벤트 목록 조회


## 💬 추가 확인 사항
- 이벤트 필터링 조회의 경우 리스트 조회 메서드 한 개에서 parameter를 다 날려서 현재 검색 동적 쿼리와 같은 방식으로 진행하려고 했으나 구독한 아티스트/팀의 경우 토큰 인증이 필요해서 로그인 하지 않은 경우 토큰 정보를 넘길 수가 없어 메서드를 다 나눠서 적었습니다. 더 좋은 방법 있으면 추천 부탁드립니다 !!!!
- 구독한 아티스트/팀 이벤트 목록 조회는 해결을 못했는데(내가 구독중인 Team, Artist 조회가 안됩니다ㅠ), 코드가 많기도 하고 수민님과 겹치는 부분도 있고.. 
  여행 이슈로 일단 pr 날리겠습니다!! 
  
