### PR TITLE
[Feature] 기본 이미지 url 반환 유틸 로직 추가

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
@@ -15,6 +15,7 @@ import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.domain.repository.UserRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import com.happiday.Happi_Day.utils.FileUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class ArtistService {
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
     private final FileUtils fileUtils;
+    private final DefaultImageUtils defaultImageUtils;
 
     // 아티스트 등록
     @Transactional
@@ -46,6 +48,8 @@ public class ArtistService {
         if (imageFile != null && !imageFile.isEmpty()) {
             String saveFileUrl = fileUtils.uploadFile(imageFile);
             artistEntity.setProfileUrl(saveFileUrl);
+        } else {
+            artistEntity.setProfileUrl(defaultImageUtils.getDefaultImageUrlTeamArtistProfile());
         }
 
         // 팀과의 연관 관계 처리

--- a/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
@@ -13,6 +13,7 @@ import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.domain.repository.UserRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import com.happiday.Happi_Day.utils.FileUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final FileUtils fileUtils;
     private final UserRepository userRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     // 팀 등록
     @Transactional
@@ -43,6 +45,8 @@ public class TeamService {
         if (imageFile != null && !imageFile.isEmpty()) {
             String saveFileUrl = fileUtils.uploadFile(imageFile);
             teamEntity.setLogoUrl(saveFileUrl);
+        } else {
+            teamEntity.setLogoUrl(defaultImageUtils.getDefaultImageUrlTeamArtistProfile());
         }
 
         teamEntity = teamRepository.save(teamEntity);

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/ArticleInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/ArticleInitService.java
@@ -8,6 +8,7 @@ import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class ArticleInitService {
     private final BoardCategoryRepository boardCategoryRepository;
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     public void initArticles() {
         User writer = userRepository.findById(2L).orElse(null);
@@ -34,6 +36,7 @@ public class ArticleInitService {
         Artist artist4 = artistRepository.findById(2L).orElse(null);
         Team team1 = teamRepository.findById(1L).orElse(null);
         Team team2 = teamRepository.findById(2L).orElse(null);
+        String imageUrl = defaultImageUtils.getDefaultImageUrlArticleThumbnail();
 
         List<Article> articles = List.of(
                 Article.builder()
@@ -43,6 +46,7 @@ public class ArticleInitService {
                         .category(category)
                         .artists(List.of(artist1, artist2))
                         .teams(List.of(team1))
+                        .thumbnailUrl(imageUrl)
                         .build(),
                 Article.builder()
                         .user(writer)
@@ -51,6 +55,7 @@ public class ArticleInitService {
                         .category(category)
                         .artists(List.of(artist3, artist4))
                         .teams(List.of(team2))
+                        .thumbnailUrl(imageUrl)
                         .build()
         );
 

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/ArtistInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/ArtistInitService.java
@@ -6,6 +6,7 @@ import com.happiday.Happi_Day.domain.repository.ArtistRepository;
 import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,31 +20,37 @@ public class ArtistInitService {
 
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     public void initArtists() {
         Team team1 = teamRepository.findById(1L).orElse(null);
         Team team2 = teamRepository.findById(2L).orElse(null);
+        String imageUrl = defaultImageUtils.getDefaultImageUrlTeamArtistProfile();
 
         List<Artist> artists = List.of(
                 Artist.builder()
                         .name("유노윤호")
                         .description("유노윤호입니다")
                         .teams(List.of(team1))
+                        .profileUrl(imageUrl)
                         .build(),
                 Artist.builder()
                         .name("시아준수")
                         .description("시아준수입니다.")
                         .teams(List.of(team1))
+                        .profileUrl(imageUrl)
                         .build(),
                 Artist.builder()
                         .name("박준형")
                         .description("박준형입니다")
                         .teams(List.of(team2))
+                        .profileUrl(imageUrl)
                         .build(),
                 Artist.builder()
                         .name("윤계상")
                         .description("윤계상입니다.")
                         .teams(List.of(team2))
+                        .profileUrl(imageUrl)
                         .build()
         );
 

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/EventInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/EventInitService.java
@@ -10,6 +10,7 @@ import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.domain.repository.UserRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class EventInitService {
     private final UserRepository userRepository;
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     public void initEvents() {
         User writer = userRepository.findById(2L).orElse(null);
@@ -35,6 +37,7 @@ public class EventInitService {
         Artist artist4 = artistRepository.findById(4L).orElse(null);
         Team team1 = teamRepository.findById(1L).orElse(null);
         Team team2 = teamRepository.findById(1L).orElse(null);
+        String imageUrl = defaultImageUtils.getDefaultImageUrlEventThumbnail();
 
         List<Event> events = List.of(
                 Event.builder()
@@ -47,6 +50,7 @@ public class EventInitService {
                         .address("올림픽로 424")
                         .artists(List.of(artist1, artist2))
                         .teams(List.of(team1))
+                        .thumbnailUrl(imageUrl)
                         .build(),
                 Event.builder()
                         .user(writer)
@@ -58,6 +62,7 @@ public class EventInitService {
                         .address("엑스코로 10")
                         .artists(List.of(artist3, artist4))
                         .teams(List.of(team2))
+                        .thumbnailUrl(imageUrl)
                         .build()
         );
 

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
@@ -9,6 +9,7 @@ import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class SalesInitService {
     private final SalesCategoryRepository salesCategoryRepository;
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     public void initSales() {
         User seller = userRepository.findById(2L).orElse(null);
@@ -37,6 +39,7 @@ public class SalesInitService {
         Artist artist4 = artistRepository.findById(4L).orElse(null);
         Team team1 = teamRepository.findById(1L).orElse(null);
         Team team2 = teamRepository.findById(1L).orElse(null);
+        String imageUrl = defaultImageUtils.getDefaultImageUrlSalesThumbnail();
 
 
         List<Sales> salesList = List.of(
@@ -49,6 +52,7 @@ public class SalesInitService {
                         .account("1234567890")
                         .startTime(LocalDateTime.of(2023,12,24,11,00))
                         .endTime(LocalDateTime.of(2023,12,31,11,00))
+                        .thumbnailImage(imageUrl)
                         .build(),
                 Sales.builder()
                         .users(seller)
@@ -59,6 +63,7 @@ public class SalesInitService {
                         .account("1234567890")
                         .startTime(LocalDateTime.of(2023,12,25,11,00))
                         .endTime(LocalDateTime.of(2023,12,31,11,00))
+                        .thumbnailImage(imageUrl)
                         .build()
         );
 

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/TeamInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/TeamInitService.java
@@ -4,6 +4,7 @@ import com.happiday.Happi_Day.domain.entity.team.Team;
 import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,16 +17,21 @@ import java.util.List;
 public class TeamInitService {
 
     private final TeamRepository teamRepository;
+    private final DefaultImageUtils defaultImageUtils;
 
     public void initTeams() {
+        String imageUrl = defaultImageUtils.getDefaultImageUrlTeamArtistProfile();
+
         List<Team> teams = List.of(
                 Team.builder()
                         .name("동방신기")
                         .description("동방신기입니다.")
+                        .logoUrl(imageUrl)
                         .build(),
                 Team.builder()
                         .name("god")
                         .description("god입니다.")
+                        .logoUrl(imageUrl)
                         .build()
         );
 

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/UserInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/UserInitService.java
@@ -5,6 +5,7 @@ import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.UserRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
+import com.happiday.Happi_Day.utils.DefaultImageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,9 +22,12 @@ public class UserInitService {
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final DefaultImageUtils defaultImageUtils;
 
     @Transactional
     public void initUsers() {
+        String imageUrl = defaultImageUtils.getDefaultImageUrlUserProfile();
+
         List<User> users = List.of(
                 // 어드민
                 User.builder()
@@ -36,6 +40,7 @@ public class UserInitService {
                         .isActive(true)
                         .isTermsAgreed(true)
                         .termsAt(LocalDateTime.now())
+
                         .build(),
                 // 유저 1 : qwer (article writer, seller)
                 User.builder()

--- a/src/main/java/com/happiday/Happi_Day/utils/DefaultImageUtils.java
+++ b/src/main/java/com/happiday/Happi_Day/utils/DefaultImageUtils.java
@@ -1,0 +1,39 @@
+package com.happiday.Happi_Day.utils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultImageUtils {
+
+    @Value("${app.default-image-url.article-thumbnail}")
+    private String defaultImageUrlArticle;
+    @Value("${app.default-image-url.event-thumbnail}")
+    private String defaultImageUrlEvent;
+    @Value("${app.default-image-url.sales-thumbnail}")
+    private String defaultImageUrlSales;
+    @Value("${app.default-image-url.user-profile}")
+    private String defaultImageUrlUser;
+    @Value("${app.default-image-url.team-artist-profile}")
+    private String defaultImageUrlTeamArtist;
+
+    public String getDefaultImageUrlArticleThumbnail() {
+        return defaultImageUrlArticle;
+    }
+
+    public String getDefaultImageUrlEventThumbnail() {
+        return defaultImageUrlEvent;
+    }
+
+    public String getDefaultImageUrlSalesThumbnail() {
+        return defaultImageUrlSales;
+    }
+
+    public String getDefaultImageUrlUserProfile() {
+        return defaultImageUrlUser;
+    }
+
+    public String getDefaultImageUrlTeamArtistProfile() {
+        return defaultImageUrlTeamArtist;
+    }
+}


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [x] 커밋 메시지, 브랜치명 컨벤션 확인
- [x] 병합되는 브랜치가 Develop인지 확인
- [x] 기능 수정 시에 테스트 코드 수정 확인
- [x] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [x] 이슈 연동 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #167 
close #167 

## 🎯 변경 사항 요약
- 기본 이미지 url 반환 유틸 로직 추가

## 📣 변경 사항 상세
- [x] 기본 이미지가 필요한 곳에 사용할 수 있도록 로직 추가
- [x] 필요한 곳 : 카드형 게시글 썸네일, 이벤트 썸네일, 굿즈 썸네일, 유저 프로필, 팀/아티스트 프로필
- [x] db seeder에서 기본 이미지를 가지도록 수정
- [x] 팀/아티스트 등록 시, 이미지가 없다면 기본 이미지를 가지도록 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
- 추가적으로 필요한 파트를 말씀해주세요!
- yml을 업데이트해주세요!