### PR TITLE
[Refactor] 구독중인 팀/아티스트 조회 관련 로직 수정 

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/repository/EventCustomRepositoryImpl.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/EventCustomRepositoryImpl.java
@@ -182,8 +182,8 @@ public class EventCustomRepositoryImpl implements EventCustomRepository{
                 .map(Team::getId)
                 .toList();
 
-        return event.artistsEventList.any().id.in(artistIds)
-                .or(event.teamsEventList.any().id.in(teamIds));
+        return event.artistsEventList.any().artist.id.in(artistIds)
+                .or(event.teamsEventList.any().team.id.in(teamIds));
 
     }
 

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/QueryArticleRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/QueryArticleRepository.java
@@ -103,8 +103,8 @@ public class QueryArticleRepository {
                 .map(Team::getId)
                 .toList();
 
-        return article.artistArticleList.any().id.in(artistIds)
-                .or(article.teamArticleList.any().id.in(teamIds));
+        return article.artistArticleList.any().artist.id.in(artistIds)
+                .or(article.teamArticleList.any().team.id.in(teamIds));
 
     }
 }


### PR DESCRIPTION
## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [ ] 커밋 메시지, 브랜치명 컨벤션 확인
- [ ] 병합되는 브랜치가 Develop인지 확인
- [ ] 기능 수정 시에 테스트 코드 수정 확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [ ] 이슈 연동 확인

## 🔗 이슈 연동

Linked Issue Number :  #217 
close #217 

## 🎯 변경 사항 요약
- 구독중인 팀/아티스트 조회 관련 로직 수정 

## 📣 변경 사항 상세
- [ ]  내가 구독한 아티스트/팀의 이벤트 조회 로직 수정
- [ ]  내가 구독한 아티스트/팀의 게시글 조회 로직 수정


## 💬 추가 확인 사항
- 매핑 테이블 엔티티 승격으로 인하여 매핑 테이블인 Artist_Event(Article), Team_Event(Article)의 id가 아닌 
  각 매핑 테이블의 artist, team의 id로 비교할 수 있도록 수정하였습니다.