### PR TITLE
[Refactor] 판매글-팀/아티스트 조인 테이블을 엔티티로 승격

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/Artist.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/Artist.java
@@ -1,7 +1,6 @@
 package com.happiday.Happi_Day.domain.entity.artist;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
-import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -47,8 +46,8 @@ public class Artist extends BaseEntity {
     private List<ArtistEvent> events = new ArrayList<>();
 
     // 판매글
-    @ManyToMany(mappedBy = "artists")
-    private List<Sales> salesList = new ArrayList<>();
+    @OneToMany(mappedBy = "artist")
+    private List<ArtistSales> artistSalesList = new ArrayList<>();
 
     // 유저 구독
     @OneToMany(mappedBy = "artist")

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/ArtistSales.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/ArtistSales.java
@@ -1,0 +1,28 @@
+package com.happiday.Happi_Day.domain.entity.artist;
+
+import com.happiday.Happi_Day.domain.entity.product.Sales;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ArtistSales {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_id")
+    private Sales sales;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/Sales.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/Sales.java
@@ -2,7 +2,7 @@ package com.happiday.Happi_Day.domain.entity.product;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
-import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -87,13 +87,8 @@ public class Sales extends BaseEntity {
     private List<ArtistSales> artistSalesList = new ArrayList<>();
 
     // 팀-판매글 매핑
-    @ManyToMany
-    @JoinTable(
-            name = "sales_team",
-            joinColumns = @JoinColumn(name = "sales_id"),
-            inverseJoinColumns = @JoinColumn(name = "team_id")
-    )
-    private List<Team> teams = new ArrayList<>();
+    @OneToMany(mappedBy = "sales")
+    private List<TeamSales> teamSalesList = new ArrayList<>();
 
     // 해시태그 매핑
     @Setter
@@ -109,7 +104,7 @@ public class Sales extends BaseEntity {
         if (sales.getDescription() != null) this.description = sales.getDescription();
         if (sales.getSalesStatus() != null) this.salesStatus = sales.getSalesStatus();
         if (sales.getArtistSalesList() != null) this.artistSalesList = sales.getArtistSalesList();
-        if (sales.getTeams() != null) this.teams = sales.getTeams();
+        if (sales.getTeamSalesList() != null) this.teamSalesList = sales.getTeamSalesList();
         if (sales.getAccount() != null) this.account = sales.getAccount();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/Sales.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/Sales.java
@@ -1,7 +1,7 @@
 package com.happiday.Happi_Day.domain.entity.product;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
-import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import jakarta.persistence.*;
@@ -83,13 +83,8 @@ public class Sales extends BaseEntity {
     private List<SalesLike> salesLikes = new ArrayList<>();
 
     // 아티스트-판매글 매핑
-    @ManyToMany
-    @JoinTable(
-            name = "sales_artist",
-            joinColumns = @JoinColumn(name = "sales_id"),
-            inverseJoinColumns = @JoinColumn(name = "artist_id")
-    )
-    private List<Artist> artists = new ArrayList<>();
+    @OneToMany(mappedBy = "sales")
+    private List<ArtistSales> artistSalesList = new ArrayList<>();
 
     // 팀-판매글 매핑
     @ManyToMany
@@ -113,7 +108,7 @@ public class Sales extends BaseEntity {
         if (sales.getName() != null) this.name = sales.getName();
         if (sales.getDescription() != null) this.description = sales.getDescription();
         if (sales.getSalesStatus() != null) this.salesStatus = sales.getSalesStatus();
-        if (sales.getArtists() != null) this.artists = sales.getArtists();
+        if (sales.getArtistSalesList() != null) this.artistSalesList = sales.getArtistSalesList();
         if (sales.getTeams() != null) this.teams = sales.getTeams();
         if (sales.getAccount() != null) this.account = sales.getAccount();
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadOneSalesDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadOneSalesDto.java
@@ -6,6 +6,7 @@ import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesHashtag;
 import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import lombok.Builder;
 import lombok.Data;
 
@@ -49,7 +50,7 @@ public class ReadOneSalesDto {
                 .likeNum(sales.getSalesLikes().size())
                 .imageList(sales.getImageUrl())
                 .artists(sales.getArtistSalesList().stream().map(ArtistSales::getArtist).map(Artist::getName).collect(Collectors.toList()))
-                .teams(sales.getTeams().stream().map(Team::getName).collect(Collectors.toList()))
+                .teams(sales.getTeamSalesList().stream().map(TeamSales::getTeam).map(Team::getName).collect(Collectors.toList()))
                 .hashtags(sales.getSalesHashtags().stream().map(SalesHashtag::getHashtag).map(Hashtag::getTag).collect(Collectors.toList()))
                 .deliveries(deliveries)
                 .startTime(sales.getStartTime())

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadOneSalesDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/ReadOneSalesDto.java
@@ -2,6 +2,7 @@ package com.happiday.Happi_Day.domain.entity.product.dto;
 
 import com.happiday.Happi_Day.domain.entity.article.Hashtag;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesHashtag;
 import com.happiday.Happi_Day.domain.entity.team.Team;
@@ -47,7 +48,7 @@ public class ReadOneSalesDto {
                 .products(productList)
                 .likeNum(sales.getSalesLikes().size())
                 .imageList(sales.getImageUrl())
-                .artists(sales.getArtists().stream().map(Artist::getName).collect(Collectors.toList()))
+                .artists(sales.getArtistSalesList().stream().map(ArtistSales::getArtist).map(Artist::getName).collect(Collectors.toList()))
                 .teams(sales.getTeams().stream().map(Team::getName).collect(Collectors.toList()))
                 .hashtags(sales.getSalesHashtags().stream().map(SalesHashtag::getHashtag).map(Hashtag::getTag).collect(Collectors.toList()))
                 .deliveries(deliveries)

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/SalesDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/SalesDetailResponseDto.java
@@ -7,6 +7,7 @@ import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesCategory;
 import com.happiday.Happi_Day.domain.entity.product.SalesStatus;
 import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,7 +39,7 @@ public class SalesDetailResponseDto {
                 .salesStatus(sales.getSalesStatus())
                 .products(sales.getProducts())
                 .artists(sales.getArtistSalesList().stream().map(ArtistSales::getArtist).toList())
-                .teams(sales.getTeams())
+                .teams(sales.getTeamSalesList().stream().map(TeamSales::getTeam).toList())
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/SalesDetailResponseDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/product/dto/SalesDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.happiday.Happi_Day.domain.entity.product.dto;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.product.Product;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesCategory;
@@ -36,7 +37,7 @@ public class SalesDetailResponseDto {
                 .imageUrl(sales.getImageUrl())
                 .salesStatus(sales.getSalesStatus())
                 .products(sales.getProducts())
-                .artists(sales.getArtists())
+                .artists(sales.getArtistSalesList().stream().map(ArtistSales::getArtist).toList())
                 .teams(sales.getTeams())
                 .build();
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/team/Team.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/team/Team.java
@@ -2,7 +2,6 @@ package com.happiday.Happi_Day.domain.entity.team;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
-import com.happiday.Happi_Day.domain.entity.product.Sales;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,8 +40,8 @@ public class Team extends BaseEntity {
     private List<TeamEvent> events = new ArrayList<>();
 
     // 판매글
-    @ManyToMany(mappedBy = "teams")
-    private List<Sales> salesList = new ArrayList<>();
+    @OneToMany(mappedBy = "team")
+    private List<TeamSales> teamSalesList = new ArrayList<>();
 
     // 유저 구독
     @OneToMany(mappedBy = "team")

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/team/TeamSales.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/team/TeamSales.java
@@ -1,0 +1,28 @@
+package com.happiday.Happi_Day.domain.entity.team;
+
+import com.happiday.Happi_Day.domain.entity.product.Sales;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class TeamSales {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sales_id")
+    private Sales sales;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistSalesRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistSalesRepository.java
@@ -1,0 +1,9 @@
+package com.happiday.Happi_Day.domain.repository;
+
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
+import com.happiday.Happi_Day.domain.entity.product.Sales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtistSalesRepository extends JpaRepository<ArtistSales, Long> {
+    void deleteBySales(Sales sales);
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/QuerySalesRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/QuerySalesRepository.java
@@ -150,7 +150,7 @@ public class QuerySalesRepository {
                 .map(Team::getId)
                 .toList();
 
-        return sales.artists.any().id.in(artistIds)
+        return sales.artistSalesList.any().id.in(artistIds)
                 .or(sales.teams.any().id.in(teamIds));
 
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/QuerySalesRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/QuerySalesRepository.java
@@ -150,8 +150,8 @@ public class QuerySalesRepository {
                 .map(Team::getId)
                 .toList();
 
-        return sales.artistSalesList.any().id.in(artistIds)
-                .or(sales.teams.any().id.in(teamIds));
+        return sales.artistSalesList.any().artist.id.in(artistIds)
+                .or(sales.teamSalesList.any().team.id.in(teamIds));
 
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/TeamSalesRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/TeamSalesRepository.java
@@ -1,0 +1,9 @@
+package com.happiday.Happi_Day.domain.repository;
+
+import com.happiday.Happi_Day.domain.entity.product.Sales;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamSalesRepository extends JpaRepository<TeamSales, Long> {
+    void deleteBySales(Sales sales);
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
@@ -2,6 +2,7 @@ package com.happiday.Happi_Day.domain.service;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistEvent;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistSubscription;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistRegisterDto;
@@ -137,7 +138,8 @@ public class ArtistService {
                 .collect(Collectors.toList());
 
         // 관련 상품 조회
-        List<SalesListResponseDto> sales = artist.getSalesList().stream()
+        List<SalesListResponseDto> sales = artist.getArtistSalesList().stream()
+                .map(ArtistSales::getSales)
                 .map(SalesListResponseDto::of)
                 .collect(Collectors.toList());
 
@@ -172,7 +174,8 @@ public class ArtistService {
         Artist artist = artistRepository.findById(artistId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTIST_NOT_FOUND));
 
-        return artist.getSalesList().stream()
+        return artist.getArtistSalesList().stream()
+                .map(ArtistSales::getSales)
                 .map(SalesListResponseDto::of)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/SalesService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/SalesService.java
@@ -6,6 +6,7 @@ import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.product.*;
 import com.happiday.Happi_Day.domain.entity.product.dto.*;
 import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
@@ -39,6 +40,7 @@ public class SalesService {
     private final ArtistRepository artistRepository;
     private final ArtistSalesRepository artistSalesRepository;
     private final TeamRepository teamRepository;
+    private final TeamSalesRepository teamSalesRepository;
     private final HashtagRepository hashtagRepository;
     private final FileUtils fileUtils;
     private final QuerySalesRepository querySalesRepository;
@@ -67,7 +69,8 @@ public class SalesService {
                 .salesStatus(SalesStatus.ON_SALE)
                 .salesCategory(category)
                 .name(dto.getName())
-                .teams(processedTags.getMiddle())
+                .artistSalesList(new ArrayList<>())
+                .teamSalesList(new ArrayList<>())
                 .salesHashtags(new ArrayList<>())
                 .description(dto.getDescription())
                 .products(productList)
@@ -87,6 +90,17 @@ public class SalesService {
                     .build();
             artistSalesRepository.save(artistSales);
             newSales.getArtistSalesList().add(artistSales);
+        }
+
+        // 팀과 판매글의 관계 설정
+        List<Team> teams = processedTags.getMiddle();
+        for (Team team : teams) {
+            TeamSales teamSales = TeamSales.builder()
+                    .sales(newSales)
+                    .team(team)
+                    .build();
+            teamSalesRepository.save(teamSales);
+            newSales.getTeamSalesList().add(teamSales);
         }
 
         List<SalesHashtag> salesHashtags = new ArrayList<>();
@@ -220,7 +234,6 @@ public class SalesService {
                 .users(user)
                 .name(dto.getName())
                 .description(dto.getDescription())
-                .teams(processedTags.getMiddle())
                 .account(dto.getAccount())
                 .startTime(dto.getStartTime())
                 .endTime(dto.getEndTime())
@@ -237,6 +250,19 @@ public class SalesService {
                     .build();
             artistSalesRepository.save(artistSales);
             sales.getArtistSalesList().add(artistSales);
+        }
+
+        // 팀과 판매글의 관계 설정
+        List<Team> teams = processedTags.getMiddle();
+        teamSalesRepository.deleteBySales(sales);
+        sales.getTeamSalesList().clear();
+        for (Team team : teams) {
+            TeamSales teamSales = TeamSales.builder()
+                    .sales(sales)
+                    .team(team)
+                    .build();
+            teamSalesRepository.save(teamSales);
+            sales.getTeamSalesList().add(teamSales);
         }
 
         if (thumbnailImage != null && !thumbnailImage.isEmpty()) {

--- a/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
@@ -5,6 +5,7 @@ import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.Team;
 import com.happiday.Happi_Day.domain.entity.team.TeamEvent;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import com.happiday.Happi_Day.domain.entity.team.TeamSubscription;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamRegisterDto;
@@ -119,7 +120,8 @@ public class TeamService {
                 .collect(Collectors.toList());
 
         // 관련 상품 조회
-        List<SalesListResponseDto> sales = team.getSalesList().stream()
+        List<SalesListResponseDto> sales = team.getTeamSalesList().stream()
+                .map(TeamSales::getSales)
                 .map(SalesListResponseDto::of)
                 .collect(Collectors.toList());
 
@@ -154,7 +156,8 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
 
-        return team.getSalesList().stream()
+        return team.getTeamSalesList().stream()
+                .map(TeamSales::getSales)
                 .map(SalesListResponseDto::of)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
@@ -1,6 +1,7 @@
 package com.happiday.Happi_Day.initialization.service;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistSales;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesCategory;
 import com.happiday.Happi_Day.domain.entity.product.SalesStatus;
@@ -26,6 +27,7 @@ public class SalesInitService {
     private final UserRepository userRepository;
     private final SalesCategoryRepository salesCategoryRepository;
     private final ArtistRepository artistRepository;
+    private final ArtistSalesRepository artistSalesRepository;
     private final TeamRepository teamRepository;
     private final DefaultImageUtils defaultImageUtils;
 
@@ -41,57 +43,70 @@ public class SalesInitService {
         Team team2 = teamRepository.findById(2L).orElse(null);
         String imageUrl = defaultImageUtils.getDefaultImageUrlSalesThumbnail();
 
+        List<Long> artistForSales1 = List.of(1L, 2L);
+        List<Long> artistForSales2 = List.of(3L, 4L);
 
-        List<Sales> salesList = List.of(
-                Sales.builder()
-                        .users(seller)
-                        .salesCategory(category1)
-                        .name("동방신기 티셔츠 팔아요.")
-                        .description("동방신기 콘서트 티셔츠 굿즈, 거의 새 것...")
-                        .salesStatus(SalesStatus.ON_SALE)
-                        .account("1234567890")
-                        .startTime(LocalDateTime.of(2023,12,24,11,00))
-                        .endTime(LocalDateTime.of(2024,1,31,11,00))
-                        .artists(List.of(artist1, artist2))
-                        .teams(List.of(team1))
-                        .build(),
-                Sales.builder()
-                        .users(seller)
-                        .salesCategory(category1)
-                        .name("동방신기 티셔츠 팔아요.(판매 기간 종료)")
-                        .description("동방신기 콘서트 티셔츠 굿즈, 거의 새 것...")
-                        .salesStatus(SalesStatus.ON_SALE)
-                        .account("1234567890")
-                        .startTime(LocalDateTime.of(2023,12,24,11,00))
-                        .endTime(LocalDateTime.of(2023,12,31,11,00))
-                        .artists(List.of(artist1, artist2))
-                        .teams(List.of(team1))
-                        .thumbnailImage(imageUrl)
-                        .build(),
-                Sales.builder()
-                        .users(seller)
-                        .salesCategory(category2)
-                        .name("god 자켓 팔아요.")
-                        .description("god 콘서트 자켓 굿즈, 거의 새 것...")
-                        .salesStatus(SalesStatus.ON_SALE)
-                        .account("1234567890")
-                        .startTime(LocalDateTime.of(2023,12,14,11,00))
-                        .endTime(LocalDateTime.of(2023,12,25,11,00))
-                        .artists(List.of(artist3, artist4))
-                        .teams(List.of(team2))
-                        .thumbnailImage(imageUrl)
-                        .build()
-        );
+        Sales sales1 = createSales(seller, category1, "동방신기 티셔츠 팔아요.",
+                "동방신기 콘서트 티셔츠 굿즈, 거의 새 것...",
+                SalesStatus.ON_SALE, "1234567890",
+                LocalDateTime.of(2023, 12, 24, 11, 00),
+                LocalDateTime.of(2024, 1, 31, 11, 00), imageUrl);
+
+        Sales sales2 = createSales(seller, category1, "동방신기 티셔츠 팔아요.(판매 기간 종료)",
+                "동방신기 콘서트 티셔츠 굿즈, 거의 새 것...",
+                SalesStatus.ON_SALE, "1234567890",
+                LocalDateTime.of(2023, 12, 24, 11, 00),
+                LocalDateTime.of(2023, 12, 31, 11, 00), imageUrl);
+
+        Sales sales3 = createSales(seller, category2, "god 자켓 팔아요.",
+                "god 콘서트 자켓 굿즈, 거의 새 것...",
+                SalesStatus.ON_SALE, "1234567890",
+                LocalDateTime.of(2023, 12, 14, 11, 00),
+                LocalDateTime.of(2023, 12, 25, 11, 00), imageUrl);
+
+        List<Sales> salesList = List.of(sales1, sales2, sales3);
 
         salesList.forEach(sales -> {
             try {
                 if (!salesRepository.existsByName(sales.getName())) {
                     salesRepository.save(sales);
+                    if (sales != sales3) {
+                        linkArtistsToSales(sales, artistForSales1);
+                    } else {
+                        linkArtistsToSales(sales, artistForSales2);
+                    }
                 }
             } catch (Exception e) {
                 log.error("DB Seeder 판매글 저장 중 예외 발생 - 판매글명: {}", sales.getName(), e);
                 throw new CustomException(ErrorCode.DB_SEEDER_SALES_SAVE_ERROR);
             }
+        });
+    }
+
+    private Sales createSales(User seller, SalesCategory category, String title, String description,
+                              SalesStatus salesStatus, String account, LocalDateTime startTime, LocalDateTime endTime, String imageUrl) {
+        return Sales.builder()
+                .users(seller)
+                .salesCategory(category)
+                .name(title)
+                .description(description)
+                .salesStatus(salesStatus)
+                .account(account)
+                .startTime(startTime)
+                .endTime(endTime)
+                .thumbnailImage(imageUrl)
+                .build();
+    }
+
+    private void linkArtistsToSales(Sales sales, List<Long> artistIds) {
+        artistIds.forEach(artistId -> {
+            artistRepository.findById(artistId).ifPresent(artist -> {
+                ArtistSales artistSales = ArtistSales.builder()
+                        .sales(sales)
+                        .artist(artist)
+                        .build();
+                artistSalesRepository.save(artistSales);
+            });
         });
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/SalesInitService.java
@@ -6,6 +6,7 @@ import com.happiday.Happi_Day.domain.entity.product.Sales;
 import com.happiday.Happi_Day.domain.entity.product.SalesCategory;
 import com.happiday.Happi_Day.domain.entity.product.SalesStatus;
 import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.team.TeamSales;
 import com.happiday.Happi_Day.domain.entity.user.User;
 import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
@@ -29,22 +30,19 @@ public class SalesInitService {
     private final ArtistRepository artistRepository;
     private final ArtistSalesRepository artistSalesRepository;
     private final TeamRepository teamRepository;
+    private final TeamSalesRepository teamSalesRepository;
     private final DefaultImageUtils defaultImageUtils;
 
     public void initSales() {
         User seller = userRepository.findById(2L).orElse(null);
         SalesCategory category1 = salesCategoryRepository.findById(1L).orElse(null);
         SalesCategory category2 = salesCategoryRepository.findById(2L).orElse(null);
-        Artist artist1 = artistRepository.findById(1L).orElse(null);
-        Artist artist2 = artistRepository.findById(2L).orElse(null);
-        Artist artist3 = artistRepository.findById(3L).orElse(null);
-        Artist artist4 = artistRepository.findById(4L).orElse(null);
-        Team team1 = teamRepository.findById(1L).orElse(null);
-        Team team2 = teamRepository.findById(2L).orElse(null);
         String imageUrl = defaultImageUtils.getDefaultImageUrlSalesThumbnail();
 
-        List<Long> artistForSales1 = List.of(1L, 2L);
-        List<Long> artistForSales2 = List.of(3L, 4L);
+        List<Long> artistsForSales1 = List.of(1L, 2L);
+        List<Long> artistsForSales2 = List.of(3L, 4L);
+        List<Long> teamsForSales1 = List.of(1L);
+        List<Long> teamsForSales2 = List.of(2L);
 
         Sales sales1 = createSales(seller, category1, "동방신기 티셔츠 팔아요.",
                 "동방신기 콘서트 티셔츠 굿즈, 거의 새 것...",
@@ -71,9 +69,11 @@ public class SalesInitService {
                 if (!salesRepository.existsByName(sales.getName())) {
                     salesRepository.save(sales);
                     if (sales != sales3) {
-                        linkArtistsToSales(sales, artistForSales1);
+                        linkArtistsToSales(sales, artistsForSales1);
+                        linkTeamsToSales(sales, teamsForSales1);
                     } else {
-                        linkArtistsToSales(sales, artistForSales2);
+                        linkArtistsToSales(sales, artistsForSales2);
+                        linkTeamsToSales(sales, teamsForSales2);
                     }
                 }
             } catch (Exception e) {
@@ -106,6 +106,18 @@ public class SalesInitService {
                         .artist(artist)
                         .build();
                 artistSalesRepository.save(artistSales);
+            });
+        });
+    }
+
+    private void linkTeamsToSales(Sales sales, List<Long> teamIds) {
+        teamIds.forEach(teamId -> {
+            teamRepository.findById(teamId).ifPresent(team -> {
+                TeamSales teamSales = TeamSales.builder()
+                        .sales(sales)
+                        .team(team)
+                        .build();
+                teamSalesRepository.save(teamSales);
             });
         });
     }


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [ ] 커밋 메시지, 브랜치명 컨벤션 확인
- [ ] 병합되는 브랜치가 Develop인지 확인
- [ ] 기능 수정 시에 테스트 코드 수정 확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [ ] 이슈 연동 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #215 
close #215 

## 🎯 변경 사항 요약
- 판매글-팀/아티스트 조인 테이블을 엔티티로 승격

## 📣 변경 사항 상세
- [ ] 기존의 아티스트-판매글 연결을 조인테이블에서 엔티티로 승격에 따른 수정
- [ ] 기존의 팀-판매글 연결을 조인테이블에서 엔티티로 승격에 따른 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->
- 일단 간단한 통합 테스트를 진행했습니다. 확인해보시고 빠진 부분있으면 말씀해주세요!