### PR TITLE
[Refactor] 팀-아티스트 소속 관계 조인테이블을 엔티티로 승격

### DIFF
--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/Artist.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/Artist.java
@@ -2,7 +2,6 @@ package com.happiday.Happi_Day.domain.entity.artist;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
-import com.happiday.Happi_Day.domain.entity.team.Team;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,13 +33,8 @@ public class Artist extends BaseEntity {
     private String profileUrl;
 
     // 팀-아티스트
-    @ManyToMany
-    @JoinTable(
-            name = "artist_team",
-            joinColumns = @JoinColumn(name = "artist_id"),
-            inverseJoinColumns = @JoinColumn(name = "team_id")
-    )
-    private List<Team> teams = new ArrayList<>();
+    @OneToMany(mappedBy = "artist")
+    private List<ArtistTeam> artistTeamList = new ArrayList<>();
 
     // 이벤트
     @OneToMany(mappedBy = "artist")
@@ -67,13 +61,15 @@ public class Artist extends BaseEntity {
         this.profileUrl = profileUrl;
     }
 
-    public void setTeams(List<Team> teams) {
-        if (this.teams == null) {
-            this.teams = new ArrayList<>();
+    public void setTeams(List<ArtistTeam> artistTeamList) {
+        if (this.artistTeamList == null) {
+            this.artistTeamList = new ArrayList<>();
+        } else {
+            this.artistTeamList.clear();
         }
-        this.teams.clear();
-        if (teams != null) {
-            this.teams.addAll(teams);
+
+        if (artistTeamList != null) {
+            this.artistTeamList.addAll(artistTeamList);
         }
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/ArtistTeam.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/ArtistTeam.java
@@ -1,0 +1,28 @@
+package com.happiday.Happi_Day.domain.entity.artist;
+
+import com.happiday.Happi_Day.domain.entity.team.Team;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ArtistTeam {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistRegisterDto.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/artist/dto/ArtistRegisterDto.java
@@ -16,7 +16,7 @@ public class ArtistRegisterDto {
         return Artist.builder()
                 .name(name)
                 .description(description)
-                .teams(new ArrayList<>())
+                .artistTeamList(new ArrayList<>())
                 .build();
     }
 }

--- a/src/main/java/com/happiday/Happi_Day/domain/entity/team/Team.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/entity/team/Team.java
@@ -1,7 +1,7 @@
 package com.happiday.Happi_Day.domain.entity.team;
 
 import com.happiday.Happi_Day.domain.entity.BaseEntity;
-import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistTeam;
 import com.happiday.Happi_Day.domain.entity.product.Sales;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -33,8 +33,8 @@ public class Team extends BaseEntity {
 
     private String logoUrl;
 
-    @ManyToMany(mappedBy = "teams")
-    private List<Artist> artists = new ArrayList<>();
+    @OneToMany(mappedBy = "team")
+    private List<ArtistTeam> artistTeamList = new ArrayList<>();
 
     // 이벤트
     @OneToMany(mappedBy = "team")

--- a/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistTeamRepository.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/repository/ArtistTeamRepository.java
@@ -1,0 +1,9 @@
+package com.happiday.Happi_Day.domain.repository;
+
+import com.happiday.Happi_Day.domain.entity.artist.Artist;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistTeam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtistTeamRepository extends JpaRepository<ArtistTeam, Long> {
+    void deleteByArtist(Artist artist);
+}

--- a/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/ArtistService.java
@@ -3,6 +3,7 @@ package com.happiday.Happi_Day.domain.service;
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistEvent;
 import com.happiday.Happi_Day.domain.entity.artist.ArtistSubscription;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistTeam;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistRegisterDto;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistDetailResponseDto;
@@ -12,10 +13,7 @@ import com.happiday.Happi_Day.domain.entity.team.Team;
 import com.happiday.Happi_Day.domain.entity.team.dto.TeamListResponseDto;
 import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
 import com.happiday.Happi_Day.domain.entity.user.User;
-import com.happiday.Happi_Day.domain.repository.ArtistRepository;
-import com.happiday.Happi_Day.domain.repository.ArtistSubscriptionRepository;
-import com.happiday.Happi_Day.domain.repository.TeamRepository;
-import com.happiday.Happi_Day.domain.repository.UserRepository;
+import com.happiday.Happi_Day.domain.repository.*;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
 import com.happiday.Happi_Day.utils.DefaultImageUtils;
@@ -39,6 +37,7 @@ public class ArtistService {
 
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final ArtistTeamRepository artistTeamRepository;
     private final UserRepository userRepository;
     private final ArtistSubscriptionRepository subscriptionRepository;
     private final FileUtils fileUtils;
@@ -60,10 +59,20 @@ public class ArtistService {
         // 팀과의 연관 관계 처리
         if (requestDto.getTeamIds() != null && !requestDto.getTeamIds().isEmpty()) {
             List<Team> teams = teamRepository.findAllById(requestDto.getTeamIds());
+            List<ArtistTeam> artistTeamList = new ArrayList<>();
 
-            artistEntity.setTeams(teams); // 아티스트와 팀 연결
+            for (Team team : teams) {
+                ArtistTeam artistTeam = ArtistTeam.builder()
+                        .artist(artistEntity)
+                        .team(team)
+                        .build();
+                artistTeamList.add(artistTeam);
+            }
+            artistTeamRepository.saveAll(artistTeamList);
+            artistEntity.setTeams(artistTeamList); // 아티스트와 팀 연결
+
             artistEntity = artistRepository.save(artistEntity);
-            return ArtistDetailResponseDto.of(artistEntity, false, teamsToDto(artistEntity.getTeams()));
+            return ArtistDetailResponseDto.of(artistEntity, false, teamsToDto(artistEntity.getArtistTeamList()));
         }
 
         artistEntity = artistRepository.save(artistEntity);
@@ -100,9 +109,22 @@ public class ArtistService {
         // 팀과의 연관 관계 처리
         if (requestDto.getTeamIds() != null) {
             List<Team> teams = teamRepository.findAllById(requestDto.getTeamIds());
-            artist.setTeams(teams);
+            artistTeamRepository.deleteByArtist(artist);
 
-            List<TeamListResponseDto> teamDtos = artist.getTeams().stream()
+            List<ArtistTeam> artistTeamList = new ArrayList<>();
+
+            for (Team team : teams) {
+                ArtistTeam artistTeam = ArtistTeam.builder()
+                        .artist(artist)
+                        .team(team)
+                        .build();
+                artistTeamList.add(artistTeam);
+            }
+            artistTeamRepository.saveAll(artistTeamList);
+            artist.setTeams(artistTeamList); // 아티스트와 팀 연결
+
+            List<TeamListResponseDto> teamDtos = artist.getArtistTeamList().stream()
+                    .map(ArtistTeam::getTeam)
                     .map(TeamListResponseDto::of)
                     .collect(Collectors.toList());
             artistRepository.save(artist);
@@ -132,7 +154,8 @@ public class ArtistService {
         boolean isSubscribed = subscriptionRepository.existsByUserAndArtist(user, artist);
 
         // 아티스트가 속한 팀 정보 가져오기
-        List<TeamListResponseDto> teams = artist.getTeams().stream()
+        List<TeamListResponseDto> teams = artist.getArtistTeamList().stream()
+                .map(ArtistTeam::getTeam)
                 .map(TeamListResponseDto::of)
                 .collect(Collectors.toList());
 
@@ -162,7 +185,8 @@ public class ArtistService {
         Artist artist = artistRepository.findById(artistId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTIST_NOT_FOUND));
 
-        return artist.getTeams().stream()
+        return artist.getArtistTeamList().stream()
+                .map(ArtistTeam::getTeam)
                 .map(TeamListResponseDto::of)
                 .collect(Collectors.toList());
     }
@@ -222,9 +246,10 @@ public class ArtistService {
         subscriptionRepository.delete(artistSubscription);
     }
 
-    // 팀을 DTO로 변환하는 유틸리티 메서드
-    private List<TeamListResponseDto> teamsToDto(List<Team> teams) {
-        return teams.stream()
+    // 아티스트-팀 연관 관계를 DTO로 변환하는 유틸리티 메서드
+    private List<TeamListResponseDto> teamsToDto(List<ArtistTeam> artistTeamList) {
+        return artistTeamList.stream()
+                .map(ArtistTeam::getTeam)
                 .map(TeamListResponseDto::of)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
+++ b/src/main/java/com/happiday/Happi_Day/domain/service/TeamService.java
@@ -1,5 +1,6 @@
 package com.happiday.Happi_Day.domain.service;
 
+import com.happiday.Happi_Day.domain.entity.artist.ArtistTeam;
 import com.happiday.Happi_Day.domain.entity.artist.dto.ArtistListResponseDto;
 import com.happiday.Happi_Day.domain.entity.event.dto.EventListResponseDto;
 import com.happiday.Happi_Day.domain.entity.product.dto.SalesListResponseDto;
@@ -91,7 +92,8 @@ public class TeamService {
         boolean isSubscribed = teamSubscriptionRepository.existsByUserAndTeam(user, team);
 
         // 팀에 소속된 아티스트 정보 가져오기
-        List<ArtistListResponseDto> artists = team.getArtists().stream()
+        List<ArtistListResponseDto> artists = team.getArtistTeamList().stream()
+                .map(ArtistTeam::getArtist)
                 .map(ArtistListResponseDto::of)
                 .collect(Collectors.toList());
         return TeamDetailResponseDto.of(team, isSubscribed, artists);
@@ -114,7 +116,8 @@ public class TeamService {
         boolean isSubscribed = teamSubscriptionRepository.existsByUserAndTeam(user, team);
 
         // 팀에 소속된 아티스트 정보 가져오기
-        List<ArtistListResponseDto> artists = team.getArtists().stream()
+        List<ArtistListResponseDto> artists = team.getArtistTeamList().stream()
+                .map(ArtistTeam::getArtist)
                 .map(ArtistListResponseDto::of)
                 .collect(Collectors.toList());
 
@@ -144,7 +147,8 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
 
-        return team.getArtists().stream()
+        return team.getArtistTeamList().stream()
+                .map(ArtistTeam::getArtist)
                 .map(ArtistListResponseDto::of)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/happiday/Happi_Day/initialization/service/ArtistInitService.java
+++ b/src/main/java/com/happiday/Happi_Day/initialization/service/ArtistInitService.java
@@ -1,8 +1,9 @@
 package com.happiday.Happi_Day.initialization.service;
 
 import com.happiday.Happi_Day.domain.entity.artist.Artist;
-import com.happiday.Happi_Day.domain.entity.team.Team;
+import com.happiday.Happi_Day.domain.entity.artist.ArtistTeam;
 import com.happiday.Happi_Day.domain.repository.ArtistRepository;
+import com.happiday.Happi_Day.domain.repository.ArtistTeamRepository;
 import com.happiday.Happi_Day.domain.repository.TeamRepository;
 import com.happiday.Happi_Day.exception.CustomException;
 import com.happiday.Happi_Day.exception.ErrorCode;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -20,49 +22,57 @@ public class ArtistInitService {
 
     private final ArtistRepository artistRepository;
     private final TeamRepository teamRepository;
+    private final ArtistTeamRepository artistTeamRepository;
     private final DefaultImageUtils defaultImageUtils;
 
     public void initArtists() {
-        Team team1 = teamRepository.findById(1L).orElse(null);
-        Team team2 = teamRepository.findById(2L).orElse(null);
         String imageUrl = defaultImageUtils.getDefaultImageUrlTeamArtistProfile();
 
-        List<Artist> artists = List.of(
-                Artist.builder()
-                        .name("유노윤호")
-                        .description("유노윤호입니다")
-                        .teams(List.of(team1))
-                        .profileUrl(imageUrl)
-                        .build(),
-                Artist.builder()
-                        .name("시아준수")
-                        .description("시아준수입니다.")
-                        .teams(List.of(team1))
-                        .profileUrl(imageUrl)
-                        .build(),
-                Artist.builder()
-                        .name("박준형")
-                        .description("박준형입니다")
-                        .teams(List.of(team2))
-                        .profileUrl(imageUrl)
-                        .build(),
-                Artist.builder()
-                        .name("윤계상")
-                        .description("윤계상입니다.")
-                        .teams(List.of(team2))
-                        .profileUrl(imageUrl)
-                        .build()
-        );
+        Artist artist1 = createArtist("유노윤호", "유노윤호입니다.", imageUrl);
+        Artist artist2 = createArtist("시아준수", "시아준수입니다.", imageUrl);
+        Artist artist3 = createArtist("박준형", "박준형입니다.", imageUrl);
+        Artist artist4 = createArtist("윤계상", "윤계상입니다.", imageUrl);
+
+        List<Long> teamIdsForArtist1 = List.of(1L);
+        List<Long> teamIdsForArtist2 = List.of(2L);
+
+        List<Artist> artists = List.of(artist1, artist2, artist3, artist4);
 
         artists.forEach(artist -> {
             try {
                 if (!artistRepository.existsByName(artist.getName())) {
+                    // 아티스트 및 팀 연결
                     artistRepository.save(artist);
+                    if (artist == artist1 || artist == artist2) {
+                        linkTeamsToArtist(artist, teamIdsForArtist1);
+                    } else {
+                        linkTeamsToArtist(artist, teamIdsForArtist2);
+                    }
                 }
             } catch (Exception e) {
                 log.error("DB Seeder 아티스트 저장 중 예외 발생 - 아티스트명: {}", artist.getName(), e);
                 throw new CustomException(ErrorCode.DB_SEEDER_ARTIST_SAVE_ERROR);
             }
+        });
+    }
+
+    private Artist createArtist(String name, String description, String imageUrl) {
+        return Artist.builder()
+                .name(name)
+                .description(description)
+                .profileUrl(imageUrl)
+                .build();
+    }
+
+    private void linkTeamsToArtist(Artist artist, List<Long> teamIds) {
+        teamIds.forEach(teamId -> {
+            teamRepository.findById(teamId).ifPresent(team -> {
+                ArtistTeam artistTeam = ArtistTeam.builder()
+                        .artist(artist)
+                        .team(team)
+                        .build();
+                artistTeamRepository.save(artistTeam);
+            });
         });
     }
 }


### PR DESCRIPTION
<!-- PR 네이밍 -->
<!-- [Feature] , [Docs], [Refactor], [Hotfix], [Project], [Test] 등  -->

## ✅ 풀리퀘스트 체크 리스트
<!-- 풀리퀘 보내는 경우 확인할 사항 -->
- [ ] 커밋 메시지, 브랜치명 컨벤션 확인
- [ ] 병합되는 브랜치가 Develop인지 확인
- [ ] 기능 수정 시에 테스트 코드 수정 확인
- [ ] 추가 문서, 설명이 필요한 경우 문서 추가 작성 확인
- [ ] 이슈 연동 확인

## 🔗 이슈 연동
<!-- 이슈 넘버와 매핑  -->
<!-- close #NN -->

Linked Issue Number :  #220 
close #220 

## 🎯 변경 사항 요약
- 팀-아티스트 소속 관계 조인테이블을 엔티티로 승격

## 📣 변경 사항 상세
- [ ] 기존의 팀-아티스트 소속 관계 조인테이블을 엔티티로 승격
- [ ] 추가적으로 주요 비즈니스 로직 수정 및 초기 덤프 데이터 매핑 수정


## 💬 추가 확인 사항
<!-- 줄글, 리스트 형식 자유 -->